### PR TITLE
Add drag-to-reorder for services and FAQs admin lists

### DIFF
--- a/app/admin/faqs/edit/EditFAQClient.tsx
+++ b/app/admin/faqs/edit/EditFAQClient.tsx
@@ -45,7 +45,6 @@ export default function EditFAQClient() {
           <AdminInput label="Question" value={form.question} required onChange={e => set("question", e.target.value)} />
           <AdminTextarea label="Answer" value={form.answer} rows={4} required onChange={e => set("answer", e.target.value)} />
           <AdminInput label="Category" value={form.category} onChange={e => set("category", e.target.value)} />
-          <AdminInput label="Display Order" type="number" value={form.order} onChange={e => set("order", Number(e.target.value))} />
           <AdminToggle label="Published" checked={form.isPublished} onChange={v => set("isPublished", v)} />
         </AdminCard>
         <div className={styles.actions}>

--- a/app/admin/faqs/new/page.tsx
+++ b/app/admin/faqs/new/page.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createFAQ } from "@/lib/firestore/mutations";
+import { getAllFAQs } from "@/lib/firestore/queries";
 import { FAQFormData } from "@/lib/types";
 import { AdminButton, AdminInput, AdminTextarea, AdminToggle, AdminCard } from "@/components/admin/ui";
 import styles from "@/styles/adminForm.module.css";
@@ -13,6 +14,12 @@ export default function NewFAQPage() {
   const [form, setForm] = useState<FAQFormData>(EMPTY);
   const [saving, setSaving] = useState(false);
   const set = (k: keyof FAQFormData, v: unknown) => setForm(f => ({ ...f, [k]: v }));
+
+  // Auto-set order to count + 1
+  useEffect(() => {
+    getAllFAQs().then(items => setForm(f => ({ ...f, order: items.length + 1 })));
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault(); setSaving(true);
     await createFAQ(form);
@@ -27,7 +34,6 @@ export default function NewFAQPage() {
           <AdminInput label="Question" value={form.question} required onChange={e => set("question", e.target.value)} />
           <AdminTextarea label="Answer" value={form.answer} rows={4} required onChange={e => set("answer", e.target.value)} />
           <AdminInput label="Category" value={form.category} hint="Optional grouping label" onChange={e => set("category", e.target.value)} />
-          <AdminInput label="Display Order" type="number" value={form.order} onChange={e => set("order", Number(e.target.value))} />
           <AdminToggle label="Published" checked={form.isPublished} onChange={v => set("isPublished", v)} />
         </AdminCard>
         <div className={styles.actions}>

--- a/app/admin/faqs/page.tsx
+++ b/app/admin/faqs/page.tsx
@@ -2,31 +2,49 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getAllFAQs } from "@/lib/firestore/queries";
+import { reorderFAQs } from "@/lib/firestore/mutations";
 import { FAQ } from "@/lib/types";
 import { AdminButton, AdminBadge, AdminCard } from "@/components/admin/ui";
+import { SortableList, DragHandle } from "@/components/admin/SortableList";
 import styles from "@/styles/adminList.module.css";
 
 export default function AdminFAQsPage() {
   const [items, setItems] = useState<FAQ[]>([]);
   const [loading, setLoading] = useState(true);
+
   useEffect(() => { getAllFAQs().then(setItems).finally(() => setLoading(false)); }, []);
+
+  const handleReorder = async (reordered: FAQ[]) => {
+    setItems(reordered);
+    await reorderFAQs(reordered.map((f, i) => ({ id: f.id, order: i + 1 })));
+  };
+
   return (
     <div className={styles.page}>
       <div className={styles.header}>
         <div><h1 className="text-h2">FAQs</h1><p className="text-body text-muted">{items.length} total</p></div>
         <Link href="/admin/faqs/new"><AdminButton>+ New FAQ</AdminButton></Link>
       </div>
-      {loading ? <div className={styles.list}>{[1,2].map(n => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
-      : items.length === 0 ? <AdminCard><p className="text-body text-muted">No FAQs yet. <Link href="/admin/faqs/new" className="text-accent">Add one →</Link></p></AdminCard>
-      : <div className={styles.list}>{items.map(f => (
-          <Link key={f.id} href={`/admin/faqs/edit?id=${f.id}`} className={styles.item}>
-            <div className={styles.itemMain}>
-              <span className="text-body font-semibold">{f.question}</span>
-              {f.category && <span className="text-body-sm text-muted">{f.category}</span>}
-            </div>
-            <AdminBadge variant={f.isPublished ? "published" : "draft"}>{f.isPublished ? "Published" : "Draft"}</AdminBadge>
-          </Link>
-        ))}</div>}
+      {loading ? (
+        <div className={styles.list}>{[1, 2].map(n => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
+      ) : items.length === 0 ? (
+        <AdminCard><p className="text-body text-muted">No FAQs yet. <Link href="/admin/faqs/new" className="text-accent">Add one →</Link></p></AdminCard>
+      ) : (
+        <div className={styles.list}>
+          <SortableList items={items} onReorder={handleReorder}>
+            {(f, handleProps) => (
+              <div className={styles.item}>
+                <DragHandle listeners={handleProps.listeners} attributes={handleProps.attributes} />
+                <Link href={`/admin/faqs/edit?id=${f.id}`} className={styles.itemMain}>
+                  <span className="text-body font-semibold">{f.question}</span>
+                  {f.category && <span className="text-body-sm text-muted">{f.category}</span>}
+                </Link>
+                <AdminBadge variant={f.isPublished ? "published" : "draft"}>{f.isPublished ? "Published" : "Draft"}</AdminBadge>
+              </div>
+            )}
+          </SortableList>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/admin/services/page.tsx
+++ b/app/admin/services/page.tsx
@@ -3,15 +3,24 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getAllServices } from "@/lib/firestore/queries";
+import { reorderServices } from "@/lib/firestore/mutations";
 import { Service } from "@/lib/types";
 import { AdminButton, AdminBadge, AdminCard } from "@/components/admin/ui";
+import { SortableList, DragHandle } from "@/components/admin/SortableList";
 import styles from "@/styles/adminList.module.css";
 
 export default function AdminServicesPage() {
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => { getAllServices().then(setServices).finally(() => setLoading(false)); }, []);
+  useEffect(() => {
+    getAllServices().then(setServices).finally(() => setLoading(false));
+  }, []);
+
+  const handleReorder = async (reordered: Service[]) => {
+    setServices(reordered);
+    await reorderServices(reordered.map((s, i) => ({ id: s.id, order: i + 1 })));
+  };
 
   return (
     <div className={styles.page}>
@@ -26,25 +35,27 @@ export default function AdminServicesPage() {
       </div>
 
       {loading ? (
-        <div className={styles.list}>{[1,2,3].map((n) => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
+        <div className={styles.list}>{[1, 2, 3].map((n) => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
       ) : services.length === 0 ? (
         <AdminCard><p className="text-body text-muted">No services yet. <Link href="/admin/services/new" className="text-accent">Create one →</Link></p></AdminCard>
       ) : (
         <div className={styles.list}>
-          {services.map((s) => (
-            <Link key={s.id} href={`/admin/services/edit?id=${s.id}`} className={styles.item}>
-              <div className={styles.itemMain}>
-                <span className="text-body font-semibold">{s.name}</span>
-                <span className="text-body-sm text-muted">/services/{s.slug}</span>
+          <SortableList items={services} onReorder={handleReorder}>
+            {(s, handleProps) => (
+              <div className={styles.item}>
+                <DragHandle listeners={handleProps.listeners} attributes={handleProps.attributes} />
+                <Link href={`/admin/services/edit?id=${s.id}`} className={styles.itemMain}>
+                  <span className="text-body font-semibold">{s.name}</span>
+                  <span className="text-body-sm text-muted">/services/{s.slug}</span>
+                </Link>
+                <div className={styles.itemMeta}>
+                  <AdminBadge variant={s.isPublished ? "published" : "draft"}>
+                    {s.isPublished ? "Published" : "Draft"}
+                  </AdminBadge>
+                </div>
               </div>
-              <div className={styles.itemMeta}>
-                <span className="text-caption text-muted">Order: {s.order}</span>
-                <AdminBadge variant={s.isPublished ? "published" : "draft"}>
-                  {s.isPublished ? "Published" : "Draft"}
-                </AdminBadge>
-              </div>
-            </Link>
-          ))}
+            )}
+          </SortableList>
         </div>
       )}
     </div>

--- a/components/admin/ServiceForm/ServiceForm.tsx
+++ b/components/admin/ServiceForm/ServiceForm.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Service, ServiceFormData } from "@/lib/types";
 import { createService, updateService, publishService, unpublishService, deleteService } from "@/lib/firestore/mutations";
+import { getAllServices } from "@/lib/firestore/queries";
 import { AdminButton, AdminInput, AdminTextarea, AdminToggle, AdminArrayField, AdminCard } from "@/components/admin/ui";
 import styles from "./ServiceForm.module.css";
 
@@ -25,6 +26,13 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
   const [form, setForm] = useState<ServiceFormData>(existing ?? EMPTY);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  // Auto-set order to count + 1 when creating a new service
+  useEffect(() => {
+    if (!existing) {
+      getAllServices().then((sv) => setForm((f) => ({ ...f, order: sv.length + 1 })));
+    }
+  }, [existing]);
 
   const set = (key: keyof ServiceFormData, value: unknown) =>
     setForm((f) => ({ ...f, [key]: value }));
@@ -78,10 +86,6 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
         <AdminTextarea
           label="Summary" value={form.summary} rows={3} required
           onChange={(e) => set("summary", e.target.value)}
-        />
-        <AdminInput
-          label="Display Order" type="number" value={form.order}
-          onChange={(e) => set("order", Number(e.target.value))}
         />
       </AdminCard>
 

--- a/components/admin/SortableList/SortableList.module.css
+++ b/components/admin/SortableList/SortableList.module.css
@@ -1,0 +1,30 @@
+.handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: var(--color-text-subtle);
+  border-radius: var(--radius-sm);
+  cursor: grab;
+  flex-shrink: 0;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.handle:hover {
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+}
+
+.handle:active {
+  cursor: grabbing;
+}
+
+.item {
+  background: var(--color-bg);
+}
+
+.dragging {
+  opacity: 0.5;
+  z-index: var(--z-raised);
+}

--- a/components/admin/SortableList/index.tsx
+++ b/components/admin/SortableList/index.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable no-restricted-syntax */
+"use client";
+
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { DraggableAttributes } from "@dnd-kit/core";
+import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
+import { ReactNode } from "react";
+import styles from "./SortableList.module.css";
+
+// ── Drag Handle ────────────────────────────────────────────
+
+interface DragHandleProps {
+  listeners?: SyntheticListenerMap;
+  attributes?: DraggableAttributes;
+}
+
+export function DragHandle({ listeners, attributes }: DragHandleProps) {
+  return (
+    <button type="button" className={styles.handle} {...listeners} {...attributes} aria-label="Drag to reorder">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <circle cx="5" cy="4" r="1.5" fill="currentColor" />
+        <circle cx="11" cy="4" r="1.5" fill="currentColor" />
+        <circle cx="5" cy="8" r="1.5" fill="currentColor" />
+        <circle cx="11" cy="8" r="1.5" fill="currentColor" />
+        <circle cx="5" cy="12" r="1.5" fill="currentColor" />
+        <circle cx="11" cy="12" r="1.5" fill="currentColor" />
+      </svg>
+    </button>
+  );
+}
+
+// ── Sortable Item ──────────────────────────────────────────
+
+interface HandleProps {
+  listeners?: SyntheticListenerMap;
+  attributes?: DraggableAttributes;
+}
+
+interface SortableItemProps {
+  id: string;
+  children: (handleProps: HandleProps) => ReactNode;
+}
+
+export function SortableItem({ id, children }: SortableItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={`${styles.item} ${isDragging ? styles.dragging : ""}`}
+    >
+      {children({ listeners, attributes })}
+    </div>
+  );
+}
+
+// ── Sortable List Container ────────────────────────────────
+
+interface SortableListProps<T extends { id: string }> {
+  items: T[];
+  onReorder: (items: T[]) => void;
+  children: (item: T, handleProps: HandleProps) => ReactNode;
+}
+
+export function SortableList<T extends { id: string }>({ items, onReorder, children }: SortableListProps<T>) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = items.findIndex((i) => i.id === active.id);
+      const newIndex = items.findIndex((i) => i.id === over.id);
+      onReorder(arrayMove(items, oldIndex, newIndex));
+    }
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+        {items.map((item) => (
+          <SortableItem key={item.id} id={item.id}>
+            {(handleProps) => children(item, handleProps)}
+          </SortableItem>
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/lib/firestore/mutations.ts
+++ b/lib/firestore/mutations.ts
@@ -7,6 +7,7 @@ import {
   updateDoc,
   deleteDoc,
   serverTimestamp,
+  writeBatch,
 } from "firebase/firestore";
 import { db, auth } from "@/lib/firebase";
 import type {
@@ -148,4 +149,25 @@ export async function updateFAQ(id: string, data: Partial<FAQFormData>): Promise
 export async function deleteFAQ(id: string, question: string): Promise<void> {
   await deleteDoc(doc(db, "faqs", id));
   await log("DELETE", "faqs", id, `Deleted FAQ: ${question}`);
+}
+
+// ── Reorder (batch) ────────────────────────────────────────
+
+async function reorderCollection(
+  collectionName: string,
+  items: { id: string; order: number }[]
+): Promise<void> {
+  const batch = writeBatch(db);
+  items.forEach(({ id, order }) => {
+    batch.update(doc(db, collectionName, id), { order });
+  });
+  await batch.commit();
+}
+
+export async function reorderServices(items: { id: string; order: number }[]): Promise<void> {
+  await reorderCollection("services", items);
+}
+
+export async function reorderFAQs(items: { id: string; order: number }[]): Promise<void> {
+  await reorderCollection("faqs", items);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "techbybrewski",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "firebase": "^11.3.1",
         "next": "^15.2.1",
         "react": "^19.0.0",
@@ -20,6 +23,59 @@
         "eslint": "^9",
         "eslint-config-next": "^15.2.1",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "firebase": "^11.3.1",
     "next": "^15.2.1",
     "react": "^19.0.0",

--- a/styles/adminList.module.css
+++ b/styles/adminList.module.css
@@ -4,5 +4,5 @@
 .skeleton { height: 72px; border-radius: var(--radius-lg); }
 .item { display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); flex-wrap: wrap; padding: var(--space-4) var(--space-5); background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-lg); transition: border-color var(--transition-fast), box-shadow var(--transition-fast); }
 .item:hover { border-color: var(--color-accent); box-shadow: var(--shadow-sm); }
-.itemMain { display: flex; flex-direction: column; gap: var(--space-1); }
+.itemMain { display: flex; flex-direction: column; gap: var(--space-1); flex: 1; min-width: 0; }
 .itemMeta { display: flex; align-items: center; gap: var(--space-3); }


### PR DESCRIPTION
- Install @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities
- New SortableList component: DragHandle (6-dot grip icon) + SortableItem + SortableList container
- Services admin list: drag handle on each row, optimistic reorder, batch Firestore write
- FAQs admin list: same pattern
- Add reorderServices() and reorderFAQs() batch mutations (writeBatch)
- ServiceForm: remove Display Order field, auto-set order = services.length + 1 on create
- FAQ new page: remove Display Order field, auto-set order = faqs.length + 1
- FAQ edit page: remove Display Order field