### PR TITLE
Add image upload to services and testimonials

### DIFF
--- a/app/(public)/services/[slug]/ServiceDetailClient.tsx
+++ b/app/(public)/services/[slug]/ServiceDetailClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import Link from "next/link";
 import { Service } from "@/lib/types";
 import styles from "./page.module.css";
@@ -10,6 +11,11 @@ export default function ServiceDetailClient({ service }: { service: Service }) {
         <Link href="/services" className={`text-label text-muted ${styles.back}`}>← Services</Link>
         <h1 className={`text-headline ${styles.title}`}>{service.name}</h1>
         <p className={`text-body-lg text-muted ${styles.summary}`}>{service.summary}</p>
+        {service.imageUrl && (
+          <div className={styles.imageWrapper}>
+            <Image src={service.imageUrl} alt={service.name} fill className={styles.image} sizes="(min-width: 768px) 768px, 100vw" />
+          </div>
+        )}
 
         <div className={styles.cols}>
           {service.bullets.length > 0 && (

--- a/app/(public)/services/[slug]/page.module.css
+++ b/app/(public)/services/[slug]/page.module.css
@@ -3,7 +3,17 @@
 .back { display: inline-block; margin-bottom: var(--space-6); transition: color var(--transition-fast); }
 .back:hover { color: var(--color-text); }
 .title { margin-bottom: var(--space-5); }
-.summary { margin-bottom: var(--space-10); }
+.summary { margin-bottom: var(--space-8); }
+.imageWrapper {
+  position: relative;
+  width: 100%;
+  height: 320px;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  margin-bottom: var(--space-10);
+}
+@media (min-width: 768px) { .imageWrapper { height: 420px; } }
+.image { object-fit: cover; }
 .cols { display: grid; grid-template-columns: 1fr; gap: var(--space-10); }
 @media (min-width: 768px) { .cols { grid-template-columns: repeat(2, 1fr); } }
 .col { display: flex; flex-direction: column; gap: var(--space-4); }

--- a/app/admin/testimonials/edit/EditTestimonialClient.tsx
+++ b/app/admin/testimonials/edit/EditTestimonialClient.tsx
@@ -1,6 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { ref, uploadBytes, getDownloadURL } from "@/lib/storage";
+import { storage } from "@/lib/firebase";
 import { getTestimonialById } from "@/lib/firestore/queries";
 import { updateTestimonial, deleteTestimonial } from "@/lib/firestore/mutations";
 import { Testimonial, TestimonialFormData } from "@/lib/types";
@@ -14,12 +16,26 @@ export default function EditTestimonialClient() {
   const [form, setForm] = useState<TestimonialFormData | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     getTestimonialById(id).then(t => { setItem(t); if (t) setForm(t); });
   }, [id]);
 
   const set = (k: keyof TestimonialFormData, v: unknown) => setForm(f => f ? { ...f, [k]: v } : f);
+
+  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const storageRef = ref(storage, `site/testimonials/${Date.now()}-${file.name}`);
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    set("avatarUrl", url);
+    setUploading(false);
+    e.target.value = "";
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,10 +64,29 @@ export default function EditTestimonialClient() {
           <AdminInput label="Name" value={form.name} required onChange={e => set("name", e.target.value)} />
           <AdminInput label="Title / Role" value={form.title} onChange={e => set("title", e.target.value)} />
           <AdminInput label="Company" value={form.company} onChange={e => set("company", e.target.value)} />
-          <AdminInput label="Avatar URL" type="url" value={form.avatarUrl} onChange={e => set("avatarUrl", e.target.value)} />
+        </AdminCard>
+
+        <AdminCard>
+          <h2 className={`text-h4 ${styles.cardTitle}`}>Avatar</h2>
+          {form.avatarUrl && (
+            <div className={styles.avatarPreview}>
+              {/* eslint-disable-next-line @next/next/no-img-element -- admin preview */}
+              <img src={form.avatarUrl} alt={form.name} className={styles.avatarThumb} />
+              <button type="button" onClick={() => set("avatarUrl", "")} className={styles.removeAvatar}>Remove</button>
+            </div>
+          )}
+          <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarUpload} className={styles.fileInput} />
+          <AdminButton type="button" variant="secondary" loading={uploading} onClick={() => fileRef.current?.click()}>
+            {uploading ? "Uploading..." : form.avatarUrl ? "Replace Photo" : "Upload Photo"}
+          </AdminButton>
+        </AdminCard>
+
+        <AdminCard>
+          <h2 className={`text-h4 ${styles.cardTitle}`}>Visibility</h2>
           <AdminInput label="Display Order" type="number" value={form.order} onChange={e => set("order", Number(e.target.value))} />
           <AdminToggle label="Published" checked={form.isPublished} onChange={v => set("isPublished", v)} />
         </AdminCard>
+
         <div className={styles.actions}>
           <AdminButton type="button" variant="danger" loading={deleting} onClick={handleDelete}>Delete</AdminButton>
           <AdminButton type="button" variant="secondary" onClick={() => router.push("/admin/testimonials")}>Cancel</AdminButton>

--- a/app/admin/testimonials/new/page.tsx
+++ b/app/admin/testimonials/new/page.tsx
@@ -1,6 +1,8 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { ref, uploadBytes, getDownloadURL } from "@/lib/storage";
+import { storage } from "@/lib/firebase";
 import { createTestimonial } from "@/lib/firestore/mutations";
 import { TestimonialFormData } from "@/lib/types";
 import { AdminButton, AdminInput, AdminTextarea, AdminToggle, AdminCard } from "@/components/admin/ui";
@@ -12,7 +14,21 @@ export default function NewTestimonialPage() {
   const router = useRouter();
   const [form, setForm] = useState<TestimonialFormData>(EMPTY);
   const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
   const set = (k: keyof TestimonialFormData, v: unknown) => setForm(f => ({ ...f, [k]: v }));
+
+  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const storageRef = ref(storage, `site/testimonials/${Date.now()}-${file.name}`);
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    set("avatarUrl", url);
+    setUploading(false);
+    e.target.value = "";
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -31,10 +47,29 @@ export default function NewTestimonialPage() {
           <AdminInput label="Name" value={form.name} required onChange={e => set("name", e.target.value)} />
           <AdminInput label="Title / Role" value={form.title} onChange={e => set("title", e.target.value)} />
           <AdminInput label="Company" value={form.company} onChange={e => set("company", e.target.value)} />
-          <AdminInput label="Avatar URL" type="url" value={form.avatarUrl} onChange={e => set("avatarUrl", e.target.value)} />
+        </AdminCard>
+
+        <AdminCard>
+          <h2 className={`text-h4 ${styles.cardTitle}`}>Avatar</h2>
+          {form.avatarUrl && (
+            <div className={styles.avatarPreview}>
+              {/* eslint-disable-next-line @next/next/no-img-element -- admin preview */}
+              <img src={form.avatarUrl} alt="Avatar preview" className={styles.avatarThumb} />
+              <button type="button" onClick={() => set("avatarUrl", "")} className={styles.removeAvatar}>Remove</button>
+            </div>
+          )}
+          <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarUpload} className={styles.fileInput} />
+          <AdminButton type="button" variant="secondary" loading={uploading} onClick={() => fileRef.current?.click()}>
+            {uploading ? "Uploading..." : form.avatarUrl ? "Replace Photo" : "Upload Photo"}
+          </AdminButton>
+        </AdminCard>
+
+        <AdminCard>
+          <h2 className={`text-h4 ${styles.cardTitle}`}>Visibility</h2>
           <AdminInput label="Display Order" type="number" value={form.order} onChange={e => set("order", Number(e.target.value))} />
           <AdminToggle label="Published" checked={form.isPublished} onChange={v => set("isPublished", v)} />
         </AdminCard>
+
         <div className={styles.actions}>
           <AdminButton type="button" variant="secondary" onClick={() => router.push("/admin/testimonials")}>Cancel</AdminButton>
           <AdminButton type="submit" loading={saving}>Create</AdminButton>

--- a/components/admin/ServiceForm/ServiceForm.module.css
+++ b/components/admin/ServiceForm/ServiceForm.module.css
@@ -1,3 +1,25 @@
 .form { display: flex; flex-direction: column; gap: var(--space-6); }
 .cardTitle { margin-bottom: var(--space-5); }
 .actions { display: flex; gap: var(--space-3); justify-content: flex-end; flex-wrap: wrap; }
+
+.imagePreview {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.thumbnail {
+  width: 160px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+.removeImage {
+  font-size: var(--text-sm);
+  color: var(--color-danger);
+  cursor: pointer;
+  padding: var(--space-1) 0;
+}
+.removeImage:hover { text-decoration: underline; }
+.fileInput { display: none; }

--- a/components/admin/ServiceForm/ServiceForm.tsx
+++ b/components/admin/ServiceForm/ServiceForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { ref, uploadBytes, getDownloadURL } from "@/lib/storage";
+import { storage } from "@/lib/firebase";
 import { Service, ServiceFormData } from "@/lib/types";
 import { createService, updateService, publishService, unpublishService, deleteService } from "@/lib/firestore/mutations";
 import { getAllServices } from "@/lib/firestore/queries";
@@ -13,7 +15,7 @@ function slugify(s: string) {
 }
 
 const EMPTY: ServiceFormData = {
-  name: "", slug: "", summary: "", bullets: [], useCases: [],
+  name: "", slug: "", summary: "", imageUrl: "", bullets: [], useCases: [],
   order: 0, isActive: true, isPublished: false,
 };
 
@@ -25,9 +27,10 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
   const router = useRouter();
   const [form, setForm] = useState<ServiceFormData>(existing ?? EMPTY);
   const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
 
-  // Auto-set order to count + 1 when creating a new service
   useEffect(() => {
     if (!existing) {
       getAllServices().then((sv) => setForm((f) => ({ ...f, order: sv.length + 1 })));
@@ -36,6 +39,18 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
 
   const set = (key: keyof ServiceFormData, value: unknown) =>
     setForm((f) => ({ ...f, [key]: value }));
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !form.slug) return alert("Set a slug before uploading an image.");
+    setUploading(true);
+    const storageRef = ref(storage, `site/services/${form.slug}/${Date.now()}-${file.name}`);
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    set("imageUrl", url);
+    setUploading(false);
+    e.target.value = "";
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,6 +102,23 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
           label="Summary" value={form.summary} rows={3} required
           onChange={(e) => set("summary", e.target.value)}
         />
+      </AdminCard>
+
+      <AdminCard>
+        <h2 className={`text-h4 ${styles.cardTitle}`}>Feature Image</h2>
+        {form.imageUrl && (
+          <div className={styles.imagePreview}>
+            {/* eslint-disable-next-line @next/next/no-img-element -- admin preview, dimensions unknown */}
+            <img src={form.imageUrl} alt="Service feature image" className={styles.thumbnail} />
+            <button type="button" onClick={() => set("imageUrl", "")} className={styles.removeImage}>
+              Remove
+            </button>
+          </div>
+        )}
+        <input ref={fileRef} type="file" accept="image/*" onChange={handleImageUpload} className={styles.fileInput} />
+        <AdminButton type="button" variant="secondary" loading={uploading} onClick={() => fileRef.current?.click()}>
+          {uploading ? "Uploading..." : form.imageUrl ? "Replace Image" : "Upload Image"}
+        </AdminButton>
       </AdminCard>
 
       <AdminCard>

--- a/lib/firestore/rest.ts
+++ b/lib/firestore/rest.ts
@@ -134,6 +134,7 @@ export async function getServiceBySlugRest(slug: string): Promise<Service | null
     name: (d.name as string) ?? "",
     slug: (d.slug as string) ?? "",
     summary: (d.summary as string) ?? "",
+    imageUrl: (d.imageUrl as string) ?? "",
     bullets: (d.bullets as string[]) ?? [],
     useCases: (d.useCases as string[]) ?? [],
     order: (d.order as number) ?? 0,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,7 @@ export interface Service {
   name: string;
   slug: string;
   summary: string;
+  imageUrl: string;
   bullets: string[];
   useCases: string[];
   order: number;

--- a/styles/adminForm.module.css
+++ b/styles/adminForm.module.css
@@ -3,3 +3,27 @@
 .cardTitle { margin-bottom: var(--space-5); }
 .actions { display: flex; gap: var(--space-3); justify-content: flex-end; flex-wrap: wrap; }
 .formSkeleton { height: 400px; border-radius: var(--radius-lg); }
+
+/* ── Image / Avatar Upload ────────────────────────────────── */
+.fileInput { display: none; }
+
+.avatarPreview {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.avatarThumb {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  border: 2px solid var(--color-border);
+  flex-shrink: 0;
+}
+.removeAvatar {
+  font-size: var(--text-sm);
+  color: var(--color-danger);
+  cursor: pointer;
+}
+.removeAvatar:hover { text-decoration: underline; }


### PR DESCRIPTION
Services:
- Add imageUrl field to Service type and rest.ts mapper
- ServiceForm: upload image to site/services/{slug}/, preview + remove
- ServiceDetailClient: render feature image below title if present

Testimonials:
- Replace Avatar URL text input with real file upload (both new + edit)
- Upload to site/testimonials/{timestamp}/, circular preview + remove
- adminForm.module.css: add .avatarPreview, .avatarThumb, .removeAvatar, .fileInput