### PR TITLE
feat: image uploads + site audit fixes

### DIFF
--- a/app/(public)/case-studies/[slug]/page.tsx
+++ b/app/(public)/case-studies/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublishedCaseStudySlugs, getCaseStudyBySlugRest } from "@/lib/firestore/rest";
 import CaseStudyDetailClient from "./CaseStudyDetailClient";
@@ -5,6 +6,26 @@ import CaseStudyDetailClient from "./CaseStudyDetailClient";
 export async function generateStaticParams() {
   const slugs = await getPublishedCaseStudySlugs();
   return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const item = await getCaseStudyBySlugRest(slug);
+  if (!item) return {};
+  const firstImage = item.images?.[0];
+  return {
+    title: item.title,
+    description: item.overview,
+    openGraph: {
+      title: item.title,
+      description: item.overview,
+      ...(firstImage ? { images: [{ url: firstImage.url, alt: firstImage.alt }] } : {}),
+    },
+  };
 }
 
 export default async function CaseStudyDetailPage({

--- a/app/(public)/case-studies/page.tsx
+++ b/app/(public)/case-studies/page.tsx
@@ -1,15 +1,16 @@
-"use client";
+import type { Metadata } from "next";
 import Image from "next/image";
-import { useEffect, useState } from "react";
 import Link from "next/link";
-import { getPublishedCaseStudies } from "@/lib/firestore/queries";
-import { CaseStudy } from "@/lib/types";
+import { getPublishedCaseStudiesRest } from "@/lib/firestore/rest";
 import styles from "./page.module.css";
 
-export default function CaseStudiesPage() {
-  const [items, setItems] = useState<CaseStudy[]>([]);
-  const [loading, setLoading] = useState(true);
-  useEffect(() => { getPublishedCaseStudies().then(setItems).finally(() => setLoading(false)); }, []);
+export const metadata: Metadata = {
+  title: "Case Studies",
+  description: "Real projects. Real outcomes. See how TechByBrewski has helped businesses solve operational challenges with custom software.",
+};
+
+export default async function CaseStudiesPage() {
+  const items = await getPublishedCaseStudiesRest();
 
   return (
     <div className="section">
@@ -18,9 +19,7 @@ export default function CaseStudiesPage() {
         <h1 className={`text-headline ${styles.title}`}>Case Studies</h1>
         <p className={`text-body-lg text-muted ${styles.intro}`}>Real projects. Real outcomes.</p>
 
-        {loading ? (
-          <div className={`grid gap-6 ${styles.grid}`}>{[1,2,3].map(n => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
-        ) : items.length === 0 ? (
+        {items.length === 0 ? (
           <p className="text-body text-muted">Case studies coming soon.</p>
         ) : (
           <div className={`grid gap-6 ${styles.grid}`}>

--- a/app/(public)/contact/ContactClient.tsx
+++ b/app/(public)/contact/ContactClient.tsx
@@ -1,0 +1,75 @@
+"use client";
+import { useActionState } from "react";
+import { useSiteSettings } from "@/lib/context/SiteSettingsContext";
+import styles from "./page.module.css";
+
+type ActionState = { ok: true } | { ok: false; error: string } | null;
+
+async function submitContact(_prev: ActionState, formData: FormData): Promise<ActionState> {
+  try {
+    const res = await fetch("/api/contact", { method: "POST", body: formData });
+    const json = await res.json();
+    if (!res.ok) return { ok: false, error: json.error ?? "Failed to send. Please try again." };
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Network error. Please try again." };
+  }
+}
+
+export default function ContactClient() {
+  const settings = useSiteSettings();
+  const [state, action, isPending] = useActionState(submitContact, null);
+
+  return (
+    <div className="section">
+      <div className={`container ${styles.inner}`}>
+        <div className={styles.header}>
+          <p className="text-overline">Start a Project</p>
+          <h1 className={`text-headline ${styles.title}`}>Let&apos;s Build Something Useful</h1>
+          <p className="text-body-lg text-muted">Tell us about your business and the system or project you&apos;re considering. We&apos;ll review the details and follow up to discuss next steps.</p>
+          {settings?.contactEmail && (
+            <p className="text-body-sm text-muted">Or email us directly at <a href={`mailto:${settings.contactEmail}`}>{settings.contactEmail}</a></p>
+          )}
+        </div>
+
+        {state?.ok ? (
+          <div className={styles.success}>
+            <p className="text-h3">Thanks for reaching out!</p>
+            <p className="text-body text-muted">We&apos;ve received your message and will be in touch shortly.</p>
+          </div>
+        ) : (
+          <form action={action} className={styles.form}>
+            <div className={styles.row}>
+              <div className={styles.field}>
+                <label className={styles.label} htmlFor="name">Your Name</label>
+                <input id="name" name="name" required className={styles.input} placeholder="Jane Smith" />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.label} htmlFor="businessName">Business Name</label>
+                <input id="businessName" name="businessName" required className={styles.input} placeholder="Acme Co." />
+              </div>
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="email">Email</label>
+              <input id="email" name="email" type="email" required className={styles.input} placeholder="you@company.com" />
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="whatBuilding">What are you looking to build?</label>
+              <input id="whatBuilding" name="whatBuilding" required className={styles.input} placeholder="e.g. An operational dashboard, a customer portal..." />
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="problem">Tell us about the problem you&apos;re trying to solve</label>
+              <textarea id="problem" name="problem" required className={styles.textarea} rows={6} placeholder="Describe the challenge your business is facing and what better software would change..." />
+            </div>
+            {state?.ok === false && (
+              <p className={styles.errorMsg}>{state.error}</p>
+            )}
+            <button type="submit" disabled={isPending} className={styles.submit}>
+              {isPending ? "Sending..." : "Send Message"}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/contact/page.module.css
+++ b/app/(public)/contact/page.module.css
@@ -35,3 +35,4 @@
 .submit:hover:not(:disabled) { opacity: 0.9; transform: translateY(-1px); box-shadow: 0 6px 20px rgba(37, 99, 235, 0.4); }
 .submit:disabled { opacity: 0.6; cursor: not-allowed; }
 .success { display: flex; flex-direction: column; gap: var(--space-4); padding: var(--space-8); background: var(--color-success-muted); border-radius: var(--radius-xl); border: 1px solid var(--color-success); }
+.errorMsg { font-size: var(--text-sm); color: var(--color-error); padding: var(--space-3) var(--space-4); background: var(--color-error-muted); border-radius: var(--radius-md); }

--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -1,75 +1,11 @@
-"use client";
-import { useState } from "react";
-import { useSiteSettings } from "@/lib/context/SiteSettingsContext";
-import styles from "./page.module.css";
+import type { Metadata } from "next";
+import ContactClient from "./ContactClient";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description: "Start a project with TechByBrewski. Tell us about your business and the system you're looking to build.",
+};
 
 export default function ContactPage() {
-  const settings = useSiteSettings();
-  const [form, setForm] = useState({ name: "", businessName: "", email: "", whatBuilding: "", problem: "" });
-  const [sent, setSent] = useState(false);
-  const [sending, setSending] = useState(false);
-
-  const set = (k: string, v: string) => setForm(f => ({ ...f, [k]: v }));
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSending(true);
-    const body = [
-      `Business: ${form.businessName}`,
-      `What they want to build: ${form.whatBuilding}`,
-      `Problem: ${form.problem}`,
-      `From: ${form.email}`,
-    ].join("\n\n");
-    const mailto = `mailto:${settings?.contactEmail || ""}?subject=New Project Inquiry from ${encodeURIComponent(form.name)}&body=${encodeURIComponent(body)}`;
-    window.location.href = mailto;
-    setSent(true);
-    setSending(false);
-  };
-
-  return (
-    <div className="section">
-      <div className={`container ${styles.inner}`}>
-        <div className={styles.header}>
-          <p className="text-overline">Start a Project</p>
-          <h1 className={`text-headline ${styles.title}`}>Let&apos;s Build Something Useful</h1>
-          <p className="text-body-lg text-muted">Tell us about your business and the system or project you&apos;re considering. We&apos;ll review the details and follow up to discuss next steps.</p>
-        </div>
-
-        {sent ? (
-          <div className={styles.success}>
-            <p className="text-h3">Thanks for reaching out!</p>
-            <p className="text-body text-muted">Your email client should have opened. We&apos;ll be in touch shortly.</p>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className={styles.form}>
-            <div className={styles.row}>
-              <div className={styles.field}>
-                <label className={styles.label} htmlFor="name">Your Name</label>
-                <input id="name" required className={styles.input} value={form.name} onChange={e => set("name", e.target.value)} placeholder="Jane Smith" />
-              </div>
-              <div className={styles.field}>
-                <label className={styles.label} htmlFor="businessName">Business Name</label>
-                <input id="businessName" required className={styles.input} value={form.businessName} onChange={e => set("businessName", e.target.value)} placeholder="Acme Co." />
-              </div>
-            </div>
-            <div className={styles.field}>
-              <label className={styles.label} htmlFor="email">Email</label>
-              <input id="email" type="email" required className={styles.input} value={form.email} onChange={e => set("email", e.target.value)} placeholder="you@company.com" />
-            </div>
-            <div className={styles.field}>
-              <label className={styles.label} htmlFor="whatBuilding">What are you looking to build?</label>
-              <input id="whatBuilding" required className={styles.input} value={form.whatBuilding} onChange={e => set("whatBuilding", e.target.value)} placeholder="e.g. An operational dashboard, a customer portal..." />
-            </div>
-            <div className={styles.field}>
-              <label className={styles.label} htmlFor="problem">Tell us about the problem you&apos;re trying to solve</label>
-              <textarea id="problem" required className={styles.textarea} rows={6} value={form.problem} onChange={e => set("problem", e.target.value)} placeholder="Describe the challenge your business is facing and what better software would change..." />
-            </div>
-            <button type="submit" disabled={sending} className={styles.submit}>
-              {sending ? "Sending..." : "Send Message"}
-            </button>
-          </form>
-        )}
-      </div>
-    </div>
-  );
+  return <ContactClient />;
 }

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -1,30 +1,20 @@
-"use client";
-
 import Image from "next/image";
-import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useSiteSettings } from "@/lib/context/SiteSettingsContext";
-import { getPublishedServices, getFeaturedCaseStudies, getPublishedTestimonials } from "@/lib/firestore/queries";
-import { Service, CaseStudy, Testimonial } from "@/lib/types";
+import {
+  getSiteSettingsRest,
+  getPublishedServicesRest,
+  getFeaturedCaseStudiesRest,
+  getPublishedTestimonialsRest,
+} from "@/lib/firestore/rest";
 import styles from "./page.module.css";
 
-export default function HomePage() {
-  const settings = useSiteSettings();
-  const [services, setServices] = useState<Service[]>([]);
-  const [caseStudies, setCaseStudies] = useState<CaseStudy[]>([]);
-  const [testimonials, setTestimonials] = useState<Testimonial[]>([]);
-
-  useEffect(() => {
-    Promise.all([
-      getPublishedServices(),
-      getFeaturedCaseStudies(3),
-      getPublishedTestimonials(),
-    ]).then(([sv, cs, t]) => {
-      setServices(sv);
-      setCaseStudies(cs);
-      setTestimonials(t);
-    });
-  }, []);
+export default async function HomePage() {
+  const [settings, services, caseStudies, testimonials] = await Promise.all([
+    getSiteSettingsRest(),
+    getPublishedServicesRest(),
+    getFeaturedCaseStudiesRest(3),
+    getPublishedTestimonialsRest(),
+  ]);
 
   const ctaHref =
     settings?.primaryCTAType === "calendly" && settings?.calendlyUrl

--- a/app/(public)/services/[slug]/page.tsx
+++ b/app/(public)/services/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublishedServiceSlugs, getServiceBySlugRest } from "@/lib/firestore/rest";
 import ServiceDetailClient from "./ServiceDetailClient";
@@ -5,6 +6,25 @@ import ServiceDetailClient from "./ServiceDetailClient";
 export async function generateStaticParams() {
   const slugs = await getPublishedServiceSlugs();
   return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const service = await getServiceBySlugRest(slug);
+  if (!service) return {};
+  return {
+    title: service.name,
+    description: service.summary,
+    openGraph: {
+      title: service.name,
+      description: service.summary,
+      ...(service.imageUrl ? { images: [{ url: service.imageUrl }] } : {}),
+    },
+  };
 }
 
 export default async function ServiceDetailPage({

--- a/app/(public)/services/page.tsx
+++ b/app/(public)/services/page.tsx
@@ -1,14 +1,15 @@
-"use client";
-import { useEffect, useState } from "react";
+import type { Metadata } from "next";
 import Link from "next/link";
-import { getPublishedServices } from "@/lib/firestore/queries";
-import { Service } from "@/lib/types";
+import { getPublishedServicesRest } from "@/lib/firestore/rest";
 import styles from "./page.module.css";
 
-export default function ServicesPage() {
-  const [services, setServices] = useState<Service[]>([]);
-  const [loading, setLoading] = useState(true);
-  useEffect(() => { getPublishedServices().then(setServices).finally(() => setLoading(false)); }, []);
+export const metadata: Metadata = {
+  title: "Services",
+  description: "Custom software solutions built for real business outcomes — operational dashboards, customer portals, workflow automation, and more.",
+};
+
+export default async function ServicesPage() {
+  const services = await getPublishedServicesRest();
 
   return (
     <div className="section">
@@ -17,10 +18,8 @@ export default function ServicesPage() {
         <h1 className={`text-headline ${styles.title}`}>Services</h1>
         <p className={`text-body-lg text-muted ${styles.intro}`}>Custom software solutions built for real business outcomes.</p>
 
-        {loading ? (
-          <div className={`grid-3 grid gap-6 ${styles.grid}`}>
-            {[1,2,3].map(n => <div key={n} className={`skeleton ${styles.cardSkeleton}`} />)}
-          </div>
+        {services.length === 0 ? (
+          <p className="text-body text-muted">Services coming soon.</p>
         ) : (
           <div className={`grid-3 grid gap-6 ${styles.grid}`}>
             {services.map(s => (

--- a/app/admin/faqs/edit/EditFAQClient.tsx
+++ b/app/admin/faqs/edit/EditFAQClient.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { getFAQById } from "@/lib/firestore/queries";
 import { updateFAQ, deleteFAQ } from "@/lib/firestore/mutations";
@@ -12,26 +12,42 @@ export default function EditFAQClient() {
   const router = useRouter();
   const [item, setItem] = useState<FAQ | null>(null);
   const [form, setForm] = useState<FAQFormData | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, startSave] = useTransition();
+  const [isDeleting, startDelete] = useTransition();
 
   useEffect(() => { getFAQById(id).then(f => { setItem(f); if (f) setForm(f); }); }, [id]);
 
   const set = (k: keyof FAQFormData, v: unknown) => setForm(f => f ? { ...f, [k]: v } : f);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!form) return;
-    setSaving(true);
-    await updateFAQ(id, form);
-    setSaving(false);
+    if (!form.question.trim() || !form.answer.trim()) {
+      setError("Question and answer are required.");
+      return;
+    }
+    setError(null);
+    startSave(async () => {
+      try {
+        await updateFAQ(id, form);
+      } catch {
+        setError("Save failed. Please try again.");
+      }
+    });
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!item || !confirm("Delete this FAQ?")) return;
-    setDeleting(true);
-    await deleteFAQ(id, item.question);
-    router.push("/admin/faqs");
+    setError(null);
+    startDelete(async () => {
+      try {
+        await deleteFAQ(id, item.question);
+        router.push("/admin/faqs");
+      } catch {
+        setError("Delete failed. Please try again.");
+      }
+    });
   };
 
   if (!form) return <div className={`skeleton ${styles.formSkeleton}`} />;
@@ -47,10 +63,13 @@ export default function EditFAQClient() {
           <AdminInput label="Category" value={form.category} onChange={e => set("category", e.target.value)} />
           <AdminToggle label="Published" checked={form.isPublished} onChange={v => set("isPublished", v)} />
         </AdminCard>
+
+        {error && <p className={styles.errorMsg}>{error}</p>}
+
         <div className={styles.actions}>
-          <AdminButton type="button" variant="danger" loading={deleting} onClick={handleDelete}>Delete</AdminButton>
+          <AdminButton type="button" variant="danger" loading={isDeleting} onClick={handleDelete}>Delete</AdminButton>
           <AdminButton type="button" variant="secondary" onClick={() => router.push("/admin/faqs")}>Cancel</AdminButton>
-          <AdminButton type="submit" loading={saving}>Save</AdminButton>
+          <AdminButton type="submit" loading={isSaving}>Save</AdminButton>
         </div>
       </form>
     </div>

--- a/app/admin/faqs/page.tsx
+++ b/app/admin/faqs/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useOptimistic, useTransition } from "react";
 import Link from "next/link";
 import { getAllFAQs } from "@/lib/firestore/queries";
 import { reorderFAQs } from "@/lib/firestore/mutations";
@@ -11,12 +11,23 @@ import styles from "@/styles/adminList.module.css";
 export default function AdminFAQsPage() {
   const [items, setItems] = useState<FAQ[]>([]);
   const [loading, setLoading] = useState(true);
+  const [reorderError, setReorderError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [optimisticItems, setOptimisticItems] = useOptimistic(items);
 
   useEffect(() => { getAllFAQs().then(setItems).finally(() => setLoading(false)); }, []);
 
-  const handleReorder = async (reordered: FAQ[]) => {
-    setItems(reordered);
-    await reorderFAQs(reordered.map((f, i) => ({ id: f.id, order: i + 1 })));
+  const handleReorder = (reordered: FAQ[]) => {
+    setReorderError(null);
+    startTransition(async () => {
+      setOptimisticItems(reordered);
+      try {
+        await reorderFAQs(reordered.map((f, i) => ({ id: f.id, order: i + 1 })));
+        setItems(reordered);
+      } catch {
+        setReorderError("Reorder failed. Please try again.");
+      }
+    });
   };
 
   return (
@@ -25,13 +36,16 @@ export default function AdminFAQsPage() {
         <div><h1 className="text-h2">FAQs</h1><p className="text-body text-muted">{items.length} total</p></div>
         <Link href="/admin/faqs/new"><AdminButton>+ New FAQ</AdminButton></Link>
       </div>
+
+      {reorderError && <p className={styles.errorMsg}>{reorderError}</p>}
+
       {loading ? (
         <div className={styles.list}>{[1, 2].map(n => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
       ) : items.length === 0 ? (
         <AdminCard><p className="text-body text-muted">No FAQs yet. <Link href="/admin/faqs/new" className="text-accent">Add one →</Link></p></AdminCard>
       ) : (
-        <div className={styles.list}>
-          <SortableList items={items} onReorder={handleReorder}>
+        <div className={`${styles.list} ${isPending ? styles.listPending : ""}`}>
+          <SortableList items={optimisticItems} onReorder={handleReorder}>
             {(f, handleProps) => (
               <div className={styles.item}>
                 <DragHandle listeners={handleProps.listeners} attributes={handleProps.attributes} />

--- a/app/admin/services/page.tsx
+++ b/app/admin/services/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useOptimistic, useTransition } from "react";
 import Link from "next/link";
 import { getAllServices } from "@/lib/firestore/queries";
 import { reorderServices } from "@/lib/firestore/mutations";
@@ -12,14 +12,25 @@ import styles from "@/styles/adminList.module.css";
 export default function AdminServicesPage() {
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
+  const [reorderError, setReorderError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [optimisticServices, setOptimisticServices] = useOptimistic(services);
 
   useEffect(() => {
     getAllServices().then(setServices).finally(() => setLoading(false));
   }, []);
 
-  const handleReorder = async (reordered: Service[]) => {
-    setServices(reordered);
-    await reorderServices(reordered.map((s, i) => ({ id: s.id, order: i + 1 })));
+  const handleReorder = (reordered: Service[]) => {
+    setReorderError(null);
+    startTransition(async () => {
+      setOptimisticServices(reordered);
+      try {
+        await reorderServices(reordered.map((s, i) => ({ id: s.id, order: i + 1 })));
+        setServices(reordered);
+      } catch {
+        setReorderError("Reorder failed. Please try again.");
+      }
+    });
   };
 
   return (
@@ -34,13 +45,15 @@ export default function AdminServicesPage() {
         </Link>
       </div>
 
+      {reorderError && <p className={styles.errorMsg}>{reorderError}</p>}
+
       {loading ? (
         <div className={styles.list}>{[1, 2, 3].map((n) => <div key={n} className={`skeleton ${styles.skeleton}`} />)}</div>
       ) : services.length === 0 ? (
         <AdminCard><p className="text-body text-muted">No services yet. <Link href="/admin/services/new" className="text-accent">Create one →</Link></p></AdminCard>
       ) : (
-        <div className={styles.list}>
-          <SortableList items={services} onReorder={handleReorder}>
+        <div className={`${styles.list} ${isPending ? styles.listPending : ""}`}>
+          <SortableList items={optimisticServices} onReorder={handleReorder}>
             {(s, handleProps) => (
               <div className={styles.item}>
                 <DragHandle listeners={handleProps.listeners} attributes={handleProps.attributes} />

--- a/app/admin/testimonials/edit/EditTestimonialClient.tsx
+++ b/app/admin/testimonials/edit/EditTestimonialClient.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { ref, uploadBytes, getDownloadURL } from "@/lib/storage";
 import { storage } from "@/lib/firebase";
@@ -14,9 +14,10 @@ export default function EditTestimonialClient() {
   const router = useRouter();
   const [item, setItem] = useState<Testimonial | null>(null);
   const [form, setForm] = useState<TestimonialFormData | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, startSave] = useTransition();
+  const [isDeleting, startDelete] = useTransition();
+  const [isUploading, startUpload] = useTransition();
   const fileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -25,31 +26,51 @@ export default function EditTestimonialClient() {
 
   const set = (k: keyof TestimonialFormData, v: unknown) => setForm(f => f ? { ...f, [k]: v } : f);
 
-  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleAvatarUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setUploading(true);
-    const storageRef = ref(storage, `site/testimonials/${Date.now()}-${file.name}`);
-    await uploadBytes(storageRef, file);
-    const url = await getDownloadURL(storageRef);
-    set("avatarUrl", url);
-    setUploading(false);
-    e.target.value = "";
+    setError(null);
+    startUpload(async () => {
+      try {
+        const storageRef = ref(storage, `site/testimonials/${Date.now()}-${file.name}`);
+        await uploadBytes(storageRef, file);
+        const url = await getDownloadURL(storageRef);
+        set("avatarUrl", url);
+        e.target.value = "";
+      } catch {
+        setError("Avatar upload failed. Please try again.");
+      }
+    });
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!form) return;
-    setSaving(true);
-    await updateTestimonial(id, form);
-    setSaving(false);
+    if (!form.quote.trim() || !form.name.trim()) {
+      setError("Quote and name are required.");
+      return;
+    }
+    setError(null);
+    startSave(async () => {
+      try {
+        await updateTestimonial(id, form);
+      } catch {
+        setError("Save failed. Please try again.");
+      }
+    });
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!item || !confirm(`Delete testimonial from "${item.name}"?`)) return;
-    setDeleting(true);
-    await deleteTestimonial(id, item.name);
-    router.push("/admin/testimonials");
+    setError(null);
+    startDelete(async () => {
+      try {
+        await deleteTestimonial(id, item.name);
+        router.push("/admin/testimonials");
+      } catch {
+        setError("Delete failed. Please try again.");
+      }
+    });
   };
 
   if (!form) return <div className={`skeleton ${styles.formSkeleton}`} />;
@@ -76,8 +97,8 @@ export default function EditTestimonialClient() {
             </div>
           )}
           <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarUpload} className={styles.fileInput} />
-          <AdminButton type="button" variant="secondary" loading={uploading} onClick={() => fileRef.current?.click()}>
-            {uploading ? "Uploading..." : form.avatarUrl ? "Replace Photo" : "Upload Photo"}
+          <AdminButton type="button" variant="secondary" loading={isUploading} onClick={() => fileRef.current?.click()}>
+            {isUploading ? "Uploading..." : form.avatarUrl ? "Replace Photo" : "Upload Photo"}
           </AdminButton>
         </AdminCard>
 
@@ -87,10 +108,12 @@ export default function EditTestimonialClient() {
           <AdminToggle label="Published" checked={form.isPublished} onChange={v => set("isPublished", v)} />
         </AdminCard>
 
+        {error && <p className={styles.errorMsg}>{error}</p>}
+
         <div className={styles.actions}>
-          <AdminButton type="button" variant="danger" loading={deleting} onClick={handleDelete}>Delete</AdminButton>
+          <AdminButton type="button" variant="danger" loading={isDeleting} onClick={handleDelete}>Delete</AdminButton>
           <AdminButton type="button" variant="secondary" onClick={() => router.push("/admin/testimonials")}>Cancel</AdminButton>
-          <AdminButton type="submit" loading={saving}>Save</AdminButton>
+          <AdminButton type="submit" loading={isSaving}>Save</AdminButton>
         </div>
       </form>
     </div>

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!;
+const API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY!;
+const BASE = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
+
+function str(value: string) {
+  return { stringValue: value };
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.formData();
+    const name = (data.get("name") as string | null)?.trim() ?? "";
+    const businessName = (data.get("businessName") as string | null)?.trim() ?? "";
+    const email = (data.get("email") as string | null)?.trim() ?? "";
+    const whatBuilding = (data.get("whatBuilding") as string | null)?.trim() ?? "";
+    const problem = (data.get("problem") as string | null)?.trim() ?? "";
+
+    if (!name || !email || !problem) {
+      return NextResponse.json({ error: "Missing required fields." }, { status: 400 });
+    }
+
+    const res = await fetch(`${BASE}/contactSubmissions?key=${API_KEY}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fields: {
+          name: str(name),
+          businessName: str(businessName),
+          email: str(email),
+          whatBuilding: str(whatBuilding),
+          problem: str(problem),
+          submittedAt: { timestampValue: new Date().toISOString() },
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error("Firestore write failed:", res.status, body);
+      return NextResponse.json({ error: "Failed to save submission." }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Contact form error:", err);
+    return NextResponse.json({ error: "An unexpected error occurred." }, { status: 500 });
+  }
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin", "/api/"],
+      },
+    ],
+    sitemap: "https://techbybrewski.com/sitemap.xml",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+import { getPublishedServiceSlugs, getPublishedCaseStudySlugs } from "@/lib/firestore/rest";
+
+const BASE_URL = "https://techbybrewski.com";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [serviceSlugs, caseStudySlugs] = await Promise.all([
+    getPublishedServiceSlugs(),
+    getPublishedCaseStudySlugs(),
+  ]);
+
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: BASE_URL, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${BASE_URL}/services`, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE_URL}/case-studies`, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE_URL}/about`, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${BASE_URL}/process`, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${BASE_URL}/contact`, changeFrequency: "yearly", priority: 0.8 },
+  ];
+
+  const servicePages: MetadataRoute.Sitemap = serviceSlugs.map((slug) => ({
+    url: `${BASE_URL}/services/${slug}`,
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }));
+
+  const caseStudyPages: MetadataRoute.Sitemap = caseStudySlugs.map((slug) => ({
+    url: `${BASE_URL}/case-studies/${slug}`,
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }));
+
+  return [...staticPages, ...servicePages, ...caseStudyPages];
+}

--- a/components/admin/CaseStudyForm/CaseStudyForm.module.css
+++ b/components/admin/CaseStudyForm/CaseStudyForm.module.css
@@ -11,3 +11,4 @@
 .removeImage { font-size: var(--text-xs); color: var(--color-danger); cursor: pointer; text-align: left; }
 
 .fileInput { display: none; }
+.errorMsg { font-size: var(--text-sm); color: var(--color-danger); padding: var(--space-3) var(--space-4); background: var(--color-error-muted, #fef2f2); border-radius: var(--radius-md); border: 1px solid var(--color-danger); }

--- a/components/admin/CaseStudyForm/CaseStudyForm.tsx
+++ b/components/admin/CaseStudyForm/CaseStudyForm.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { ref, uploadBytes, getDownloadURL } from "@/lib/storage";
 import { storage } from "@/lib/firebase";
 import { CaseStudy, CaseStudyFormData } from "@/lib/types";
 import { createCaseStudy, updateCaseStudy, publishCaseStudy, unpublishCaseStudy, deleteCaseStudy } from "@/lib/firestore/mutations";
 import { AdminButton, AdminInput, AdminTextarea, AdminToggle, AdminArrayField, AdminCard } from "@/components/admin/ui";
+import { slugify } from "@/lib/utils";
 import styles from "./CaseStudyForm.module.css";
-
-function slugify(s: string) {
-  return s.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-}
 
 const EMPTY: CaseStudyFormData = {
   title: "", slug: "", clientName: "", industry: "", overview: "",
@@ -22,56 +19,88 @@ const EMPTY: CaseStudyFormData = {
 export default function CaseStudyForm({ existing }: { existing?: CaseStudy }) {
   const router = useRouter();
   const [form, setForm] = useState<CaseStudyFormData>(existing ?? EMPTY);
-  const [saving, setSaving] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, startSave] = useTransition();
+  const [isDeleting, startDelete] = useTransition();
+  const [isUploading, startUpload] = useTransition();
+  const [, startPublish] = useTransition();
   const fileRef = useRef<HTMLInputElement>(null);
 
   const set = (key: keyof CaseStudyFormData, value: unknown) =>
     setForm((f) => ({ ...f, [key]: value }));
 
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file || !form.slug) return alert("Set a slug before uploading images.");
-    setUploading(true);
-    const storageRef = ref(storage, `site/caseStudies/${form.slug}/${Date.now()}-${file.name}`);
-    await uploadBytes(storageRef, file);
-    const url = await getDownloadURL(storageRef);
-    set("images", [...form.images, { url, alt: file.name.replace(/\.[^.]+$/, ""), order: form.images.length }]);
-    setUploading(false);
-    e.target.value = "";
+    if (!file) return;
+    if (!form.slug) {
+      setError("Set a slug before uploading images.");
+      return;
+    }
+    setError(null);
+    startUpload(async () => {
+      try {
+        const storageRef = ref(storage, `site/caseStudies/${form.slug}/${Date.now()}-${file.name}`);
+        await uploadBytes(storageRef, file);
+        const url = await getDownloadURL(storageRef);
+        set("images", [...form.images, { url, alt: file.name.replace(/\.[^.]+$/, ""), order: form.images.length }]);
+        e.target.value = "";
+      } catch {
+        setError("Image upload failed. Please try again.");
+      }
+    });
   };
 
   const removeImage = (i: number) => set("images", form.images.filter((_, idx) => idx !== i));
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setSaving(true);
-    if (existing) {
-      await updateCaseStudy(existing.id, form);
-    } else {
-      const id = await createCaseStudy(form);
-      router.push(`/admin/case-studies/edit?id=${id}`);
+    if (!form.title.trim() || !form.slug.trim() || !form.overview.trim()) {
+      setError("Title, slug, and overview are required.");
       return;
     }
-    setSaving(false);
+    setError(null);
+    startSave(async () => {
+      try {
+        if (existing) {
+          await updateCaseStudy(existing.id, form);
+        } else {
+          const id = await createCaseStudy(form);
+          router.push(`/admin/case-studies/edit?id=${id}`);
+        }
+      } catch {
+        setError("Save failed. Please try again.");
+      }
+    });
   };
 
-  const handlePublishToggle = async () => {
+  const handlePublishToggle = () => {
     if (!existing) return;
-    if (form.isPublished) {
-      await unpublishCaseStudy(existing.id, form.title);
-    } else {
-      await publishCaseStudy(existing.id, form.title, existing.isPublished);
-    }
-    set("isPublished", !form.isPublished);
+    setError(null);
+    startPublish(async () => {
+      try {
+        if (form.isPublished) {
+          await unpublishCaseStudy(existing.id, form.title);
+        } else {
+          await publishCaseStudy(existing.id, form.title, existing.isPublished);
+        }
+        set("isPublished", !form.isPublished);
+      } catch {
+        setError("Failed to update publish status.");
+      }
+    });
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!existing || !confirm(`Delete "${form.title}"? This cannot be undone.`)) return;
-    setDeleting(true);
-    await deleteCaseStudy(existing.id, form.title);
-    router.push("/admin/case-studies");
+    setError(null);
+    startDelete(async () => {
+      try {
+        await deleteCaseStudy(existing.id, form.title);
+        router.push("/admin/case-studies");
+      } catch {
+        setError("Delete failed. Please try again.");
+      }
+    });
   };
 
   return (
@@ -114,8 +143,8 @@ export default function CaseStudyForm({ existing }: { existing?: CaseStudy }) {
           </div>
         )}
         <input ref={fileRef} type="file" accept="image/*" onChange={handleImageUpload} className={styles.fileInput} />
-        <AdminButton type="button" variant="secondary" loading={uploading} onClick={() => fileRef.current?.click()}>
-          {uploading ? "Uploading..." : "Upload Image"}
+        <AdminButton type="button" variant="secondary" loading={isUploading} onClick={() => fileRef.current?.click()}>
+          {isUploading ? "Uploading..." : "Upload Image"}
         </AdminButton>
       </AdminCard>
 
@@ -125,10 +154,12 @@ export default function CaseStudyForm({ existing }: { existing?: CaseStudy }) {
         {existing && <AdminToggle label="Published" hint="Visible on public site" checked={form.isPublished} onChange={handlePublishToggle} />}
       </AdminCard>
 
+      {error && <p className={styles.errorMsg}>{error}</p>}
+
       <div className={styles.actions}>
-        {existing && <AdminButton type="button" variant="danger" loading={deleting} onClick={handleDelete}>Delete</AdminButton>}
+        {existing && <AdminButton type="button" variant="danger" loading={isDeleting} onClick={handleDelete}>Delete</AdminButton>}
         <AdminButton type="button" variant="secondary" onClick={() => router.push("/admin/case-studies")}>Cancel</AdminButton>
-        <AdminButton type="submit" loading={saving}>{existing ? "Save Changes" : "Create Case Study"}</AdminButton>
+        <AdminButton type="submit" loading={isSaving}>{existing ? "Save Changes" : "Create Case Study"}</AdminButton>
       </div>
     </form>
   );

--- a/components/admin/ServiceForm/ServiceForm.module.css
+++ b/components/admin/ServiceForm/ServiceForm.module.css
@@ -23,3 +23,4 @@
 }
 .removeImage:hover { text-decoration: underline; }
 .fileInput { display: none; }
+.errorMsg { font-size: var(--text-sm); color: var(--color-danger); padding: var(--space-3) var(--space-4); background: var(--color-error-muted, #fef2f2); border-radius: var(--radius-md); border: 1px solid var(--color-danger); }

--- a/components/admin/ServiceForm/ServiceForm.tsx
+++ b/components/admin/ServiceForm/ServiceForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { ref, uploadBytes, getDownloadURL } from "@/lib/storage";
 import { storage } from "@/lib/firebase";
@@ -8,11 +8,8 @@ import { Service, ServiceFormData } from "@/lib/types";
 import { createService, updateService, publishService, unpublishService, deleteService } from "@/lib/firestore/mutations";
 import { getAllServices } from "@/lib/firestore/queries";
 import { AdminButton, AdminInput, AdminTextarea, AdminToggle, AdminArrayField, AdminCard } from "@/components/admin/ui";
+import { slugify } from "@/lib/utils";
 import styles from "./ServiceForm.module.css";
-
-function slugify(s: string) {
-  return s.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
-}
 
 const EMPTY: ServiceFormData = {
   name: "", slug: "", summary: "", imageUrl: "", bullets: [], useCases: [],
@@ -26,9 +23,11 @@ interface ServiceFormProps {
 export default function ServiceForm({ existing }: ServiceFormProps) {
   const router = useRouter();
   const [form, setForm] = useState<ServiceFormData>(existing ?? EMPTY);
-  const [saving, setSaving] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, startSave] = useTransition();
+  const [isDeleting, startDelete] = useTransition();
+  const [isUploading, startUpload] = useTransition();
+  const [, startPublish] = useTransition();
   const fileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -40,46 +39,76 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
   const set = (key: keyof ServiceFormData, value: unknown) =>
     setForm((f) => ({ ...f, [key]: value }));
 
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file || !form.slug) return alert("Set a slug before uploading an image.");
-    setUploading(true);
-    const storageRef = ref(storage, `site/services/${form.slug}/${Date.now()}-${file.name}`);
-    await uploadBytes(storageRef, file);
-    const url = await getDownloadURL(storageRef);
-    set("imageUrl", url);
-    setUploading(false);
-    e.target.value = "";
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    if (existing) {
-      await updateService(existing.id, form);
-    } else {
-      const id = await createService(form);
-      router.push(`/admin/services/edit?id=${id}`);
+    if (!file) return;
+    if (!form.slug) {
+      setError("Set a slug before uploading an image.");
       return;
     }
-    setSaving(false);
+    setError(null);
+    startUpload(async () => {
+      try {
+        const storageRef = ref(storage, `site/services/${form.slug}/${Date.now()}-${file.name}`);
+        await uploadBytes(storageRef, file);
+        const url = await getDownloadURL(storageRef);
+        set("imageUrl", url);
+        e.target.value = "";
+      } catch {
+        setError("Image upload failed. Please try again.");
+      }
+    });
   };
 
-  const handlePublishToggle = async () => {
-    if (!existing) return;
-    if (form.isPublished) {
-      await unpublishService(existing.id, form.name);
-    } else {
-      await publishService(existing.id, form.name);
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim() || !form.slug.trim() || !form.summary.trim()) {
+      setError("Name, slug, and summary are required.");
+      return;
     }
-    set("isPublished", !form.isPublished);
+    setError(null);
+    startSave(async () => {
+      try {
+        if (existing) {
+          await updateService(existing.id, form);
+        } else {
+          const id = await createService(form);
+          router.push(`/admin/services/edit?id=${id}`);
+        }
+      } catch {
+        setError("Save failed. Please try again.");
+      }
+    });
   };
 
-  const handleDelete = async () => {
+  const handlePublishToggle = () => {
+    if (!existing) return;
+    setError(null);
+    startPublish(async () => {
+      try {
+        if (form.isPublished) {
+          await unpublishService(existing.id, form.name);
+        } else {
+          await publishService(existing.id, form.name);
+        }
+        set("isPublished", !form.isPublished);
+      } catch {
+        setError("Failed to update publish status.");
+      }
+    });
+  };
+
+  const handleDelete = () => {
     if (!existing || !confirm(`Delete "${form.name}"? This cannot be undone.`)) return;
-    setDeleting(true);
-    await deleteService(existing.id, form.name);
-    router.push("/admin/services");
+    setError(null);
+    startDelete(async () => {
+      try {
+        await deleteService(existing.id, form.name);
+        router.push("/admin/services");
+      } catch {
+        setError("Delete failed. Please try again.");
+      }
+    });
   };
 
   return (
@@ -116,8 +145,8 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
           </div>
         )}
         <input ref={fileRef} type="file" accept="image/*" onChange={handleImageUpload} className={styles.fileInput} />
-        <AdminButton type="button" variant="secondary" loading={uploading} onClick={() => fileRef.current?.click()}>
-          {uploading ? "Uploading..." : form.imageUrl ? "Replace Image" : "Upload Image"}
+        <AdminButton type="button" variant="secondary" loading={isUploading} onClick={() => fileRef.current?.click()}>
+          {isUploading ? "Uploading..." : form.imageUrl ? "Replace Image" : "Upload Image"}
         </AdminButton>
       </AdminCard>
 
@@ -131,20 +160,27 @@ export default function ServiceForm({ existing }: ServiceFormProps) {
         <h2 className={`text-h4 ${styles.cardTitle}`}>Visibility</h2>
         <AdminToggle label="Active" hint="Show in services listing" checked={form.isActive} onChange={(v) => set("isActive", v)} />
         {existing && (
-          <AdminToggle label="Published" hint="Visible on public site" checked={form.isPublished} onChange={handlePublishToggle} />
+          <AdminToggle
+            label="Published"
+            hint="Visible on public site"
+            checked={form.isPublished}
+            onChange={handlePublishToggle}
+          />
         )}
       </AdminCard>
 
+      {error && <p className={styles.errorMsg}>{error}</p>}
+
       <div className={styles.actions}>
         {existing && (
-          <AdminButton type="button" variant="danger" loading={deleting} onClick={handleDelete}>
+          <AdminButton type="button" variant="danger" loading={isDeleting} onClick={handleDelete}>
             Delete
           </AdminButton>
         )}
         <AdminButton type="button" variant="secondary" onClick={() => router.push("/admin/services")}>
           Cancel
         </AdminButton>
-        <AdminButton type="submit" loading={saving}>
+        <AdminButton type="submit" loading={isSaving}>
           {existing ? "Save Changes" : "Create Service"}
         </AdminButton>
       </div>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,14 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "isPublished", "order": "ASCENDING" },
+        { "fieldPath": "order", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "caseStudies",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isPublished", "order": "ASCENDING" },
         { "fieldPath": "featured", "order": "ASCENDING" },
         { "fieldPath": "order", "order": "ASCENDING" }
       ]
@@ -39,6 +47,13 @@
       "fields": [
         { "fieldPath": "isPublished", "order": "ASCENDING" },
         { "fieldPath": "order", "order": "ASCENDING" }
+      ]
+    }
+    {
+      "collectionGroup": "activityLog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
       ]
     }
   ],

--- a/firestore.rules
+++ b/firestore.rules
@@ -46,6 +46,13 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
+    // ---- Contact Submissions ----
+    // Anyone can create (public contact form); only admins can read
+    match /contactSubmissions/{id} {
+      allow create: if true;
+      allow read, update, delete: if isAdmin();
+    }
+
     // ---- Activity Log ----
     // Admins can write and read; no public access
     match /activityLog/{id} {

--- a/lib/firestore/rest.ts
+++ b/lib/firestore/rest.ts
@@ -4,7 +4,7 @@
  * No Firebase SDK — plain fetch over HTTP.
  */
 
-import { Service, CaseStudy, CaseStudyImage } from "@/lib/types";
+import { Service, CaseStudy, CaseStudyImage, Testimonial, SiteSettings } from "@/lib/types";
 
 const PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!;
 const API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY!;
@@ -53,7 +53,9 @@ interface FieldFilter {
 async function runQuery(
   collectionId: string,
   filters: FieldFilter[],
-  orderBy?: { field: string; direction?: "ASCENDING" | "DESCENDING" }
+  orderBy?: { field: string; direction?: "ASCENDING" | "DESCENDING" },
+  limitTo?: number,
+  cache: RequestCache = "no-store"
 ): Promise<Array<Record<string, unknown> & { id: string }>> {
   function toFsValue(val: string | number | boolean): FsValue {
     if (typeof val === "string") return { stringValue: val };
@@ -96,12 +98,20 @@ async function runQuery(
     ];
   }
 
+  if (limitTo) {
+    (body.structuredQuery as Record<string, unknown>).limit = limitTo;
+  }
+
   const res = await fetch(`${BASE}:runQuery?key=${API_KEY}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    cache: "no-store", // always fresh at build time
+    cache,
   });
+
+  if (!res.ok) {
+    throw new Error(`Firestore REST query failed: ${res.status} ${res.statusText}`);
+  }
 
   const rows = (await res.json()) as Array<{
     document?: { name: string; fields: Record<string, FsValue> };
@@ -116,6 +126,157 @@ async function runQuery(
 }
 
 // ── Public query helpers ───────────────────────────────────────
+
+// ── Single-document fetch ──────────────────────────────────────
+
+async function getDocument(
+  collectionId: string,
+  docId: string
+): Promise<Record<string, unknown> | null> {
+  const res = await fetch(`${BASE}/${collectionId}/${docId}?key=${API_KEY}`, {
+    cache: "no-store",
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`Firestore REST getDocument failed: ${res.status} ${res.statusText}`);
+  }
+  const doc = (await res.json()) as { fields?: Record<string, FsValue> };
+  if (!doc.fields) return null;
+  return decodeMap(doc.fields);
+}
+
+export async function getSiteSettingsRest(): Promise<SiteSettings | null> {
+  const d = await getDocument("siteSettings", "main");
+  if (!d) return null;
+  const socialLinks = (d.socialLinks as Record<string, unknown>) ?? {};
+  const seoDefaults = (d.seoDefaults as Record<string, unknown>) ?? {};
+  return {
+    brandName: (d.brandName as string) ?? "",
+    tagline: (d.tagline as string) ?? "",
+    heroHeadline: (d.heroHeadline as string) ?? "",
+    heroSubheadline: (d.heroSubheadline as string) ?? "",
+    primaryCTAType: ((d.primaryCTAType as string) ?? "contact") as "calendly" | "contact",
+    calendlyUrl: (d.calendlyUrl as string) ?? "",
+    contactEmail: (d.contactEmail as string) ?? "",
+    socialLinks: {
+      linkedin: (socialLinks.linkedin as string) ?? "",
+      github: (socialLinks.github as string) ?? "",
+      instagram: (socialLinks.instagram as string) ?? "",
+    },
+    seoDefaults: {
+      titleTemplate: (seoDefaults.titleTemplate as string) ?? "",
+      defaultDescription: (seoDefaults.defaultDescription as string) ?? "",
+    },
+  };
+}
+
+export async function getPublishedServicesRest(): Promise<Service[]> {
+  const docs = await runQuery(
+    "services",
+    [{ field: "isPublished", op: "EQUAL", value: true }],
+    { field: "order", direction: "ASCENDING" }
+  );
+  return docs.map((d) => ({
+    id: d.id,
+    name: (d.name as string) ?? "",
+    slug: (d.slug as string) ?? "",
+    summary: (d.summary as string) ?? "",
+    imageUrl: (d.imageUrl as string) ?? "",
+    bullets: (d.bullets as string[]) ?? [],
+    useCases: (d.useCases as string[]) ?? [],
+    order: (d.order as number) ?? 0,
+    isActive: (d.isActive as boolean) ?? false,
+    isPublished: (d.isPublished as boolean) ?? false,
+  }));
+}
+
+export async function getFeaturedCaseStudiesRest(max = 3): Promise<CaseStudy[]> {
+  const docs = await runQuery(
+    "caseStudies",
+    [
+      { field: "isPublished", op: "EQUAL", value: true },
+      { field: "featured", op: "EQUAL", value: true },
+    ],
+    { field: "order", direction: "ASCENDING" },
+    max
+  );
+  return docs.map((d) => {
+    const rawImages = (d.images as Array<Record<string, unknown>>) ?? [];
+    return {
+      id: d.id,
+      title: (d.title as string) ?? "",
+      slug: (d.slug as string) ?? "",
+      clientName: (d.clientName as string) ?? "",
+      industry: (d.industry as string) ?? "",
+      overview: (d.overview as string) ?? "",
+      problem: (d.problem as string[]) ?? [],
+      solution: (d.solution as string[]) ?? [],
+      outcomes: (d.outcomes as string[]) ?? [],
+      stack: (d.stack as string[]) ?? [],
+      images: rawImages.map((img) => ({
+        url: (img.url as string) ?? "",
+        alt: (img.alt as string) ?? "",
+        order: (img.order as number) ?? 0,
+      })),
+      featured: (d.featured as boolean) ?? false,
+      order: (d.order as number) ?? 0,
+      publishedAt: null,
+      updatedAt: null,
+      isPublished: (d.isPublished as boolean) ?? false,
+    };
+  });
+}
+
+export async function getPublishedCaseStudiesRest(): Promise<CaseStudy[]> {
+  const docs = await runQuery(
+    "caseStudies",
+    [{ field: "isPublished", op: "EQUAL", value: true }],
+    { field: "order", direction: "ASCENDING" }
+  );
+  return docs.map((d) => {
+    const rawImages = (d.images as Array<Record<string, unknown>>) ?? [];
+    return {
+      id: d.id,
+      title: (d.title as string) ?? "",
+      slug: (d.slug as string) ?? "",
+      clientName: (d.clientName as string) ?? "",
+      industry: (d.industry as string) ?? "",
+      overview: (d.overview as string) ?? "",
+      problem: (d.problem as string[]) ?? [],
+      solution: (d.solution as string[]) ?? [],
+      outcomes: (d.outcomes as string[]) ?? [],
+      stack: (d.stack as string[]) ?? [],
+      images: rawImages.map((img) => ({
+        url: (img.url as string) ?? "",
+        alt: (img.alt as string) ?? "",
+        order: (img.order as number) ?? 0,
+      })),
+      featured: (d.featured as boolean) ?? false,
+      order: (d.order as number) ?? 0,
+      publishedAt: null,
+      updatedAt: null,
+      isPublished: (d.isPublished as boolean) ?? false,
+    };
+  });
+}
+
+export async function getPublishedTestimonialsRest(): Promise<Testimonial[]> {
+  const docs = await runQuery(
+    "testimonials",
+    [{ field: "isPublished", op: "EQUAL", value: true }],
+    { field: "order", direction: "ASCENDING" }
+  );
+  return docs.map((d) => ({
+    id: d.id,
+    quote: (d.quote as string) ?? "",
+    name: (d.name as string) ?? "",
+    title: (d.title as string) ?? "",
+    company: (d.company as string) ?? "",
+    avatarUrl: (d.avatarUrl as string) ?? "",
+    order: (d.order as number) ?? 0,
+    isPublished: (d.isPublished as boolean) ?? false,
+  }));
+}
 
 export async function getPublishedServiceSlugs(): Promise<string[]> {
   const docs = await runQuery("services", [{ field: "isPublished", op: "EQUAL", value: true }]);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,8 @@
+export function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/styles/adminForm.module.css
+++ b/styles/adminForm.module.css
@@ -27,3 +27,4 @@
   cursor: pointer;
 }
 .removeAvatar:hover { text-decoration: underline; }
+.errorMsg { font-size: var(--text-sm); color: var(--color-danger); padding: var(--space-3) var(--space-4); background: var(--color-error-muted, #fef2f2); border-radius: var(--radius-md); border: 1px solid var(--color-danger); }

--- a/styles/adminList.module.css
+++ b/styles/adminList.module.css
@@ -6,3 +6,5 @@
 .item:hover { border-color: var(--color-accent); box-shadow: var(--shadow-sm); }
 .itemMain { display: flex; flex-direction: column; gap: var(--space-1); flex: 1; min-width: 0; }
 .itemMeta { display: flex; align-items: center; gap: var(--space-3); }
+.listPending { opacity: 0.7; pointer-events: none; }
+.errorMsg { font-size: var(--text-sm); color: var(--color-danger); padding: var(--space-3) var(--space-4); background: var(--color-error-muted, #fef2f2); border-radius: var(--radius-md); border: 1px solid var(--color-danger); }


### PR DESCRIPTION
## Summary

- **Image uploads** — service feature images and testimonial avatars now upload to Firebase Storage directly from admin forms
- **Homepage/list pages → SSG** — converted `page.tsx`, `/services`, `/case-studies` from `"use client"` + `useEffect` to Server Components; content is now fully server-rendered for SEO
- **Contact form fixed** — replaced `mailto:` redirect with a real API route (`/api/contact`) that stores submissions in Firestore `contactSubmissions`; uses React 19 `useActionState` for pending/error state
- **React 19 error handling** — `useTransition` on all admin form save/delete/upload/publish ops with inline error display; `useOptimistic` on services + FAQs list pages for reorder rollback
- **REST API hardened** — `res.ok` check added to `lib/firestore/rest.ts`; build now fails visibly on Firestore API errors
- **SEO** — `metadata` exports added to Services, Case Studies, Contact pages; `generateMetadata` on detail pages (`/services/[slug]`, `/case-studies/[slug]`) for per-page title/description/OG tags
- **robots.ts + sitemap.ts** — disallows `/admin` and `/api/`; dynamic sitemap includes all published service + case study slugs
- **Form validation** — required field checks before submit on all admin forms; `slugify` extracted to `lib/utils.ts` (also fixed double-hyphen bug)
- **Firestore indexes** — composite indexes added to `firestore.indexes.json` for all `isPublished + order` queries
- **Firestore rules** — `contactSubmissions` collection added (public `create`, admin-only `read`)

## Test plan

- [ ] `npm run build` passes with 0 errors
- [ ] Visit `/` — content visible in View Source (no blank body)
- [ ] Visit `/services` and `/case-studies` — server-rendered content
- [ ] Submit contact form — submission appears in Firestore `contactSubmissions`
- [ ] Visit `/robots.txt` and `/sitemap.xml` — valid responses
- [ ] `/services/[slug]` page `<title>` matches the service name
- [ ] Admin: save service with empty name → validation error shown, no Firestore write
- [ ] Admin: drag to reorder services/FAQs → optimistic update; on failure, list reverts
- [ ] Deploy Firestore rules + indexes: `firebase deploy --only firestore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)