### PR TITLE
feat: design polish pass — Navbar branding, Footer redesign, a11y improvements

### DIFF
--- a/app/(public)/about/page.module.css
+++ b/app/(public)/about/page.module.css
@@ -37,7 +37,7 @@
 
 /* ── Who We Help ──────────────────────────────────────────── */
 .whoIntro {
-  max-width: 600px;
+  max-width: var(--container-sm);
   margin-bottom: var(--space-8);
 }
 
@@ -76,7 +76,7 @@
   display: inline-flex;
   align-items: center;
   padding: var(--space-3) var(--space-8);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-semibold);
   border-radius: var(--radius-full);

--- a/app/(public)/about/page.tsx
+++ b/app/(public)/about/page.tsx
@@ -36,7 +36,7 @@ const VALUES = [
 
 export default function AboutPage() {
   return (
-    <div className="section">
+    <section className="section">
       <div className="container">
 
         {/* Mission */}
@@ -87,6 +87,6 @@ export default function AboutPage() {
         </div>
 
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/(public)/case-studies/[slug]/CaseStudyDetailClient.tsx
+++ b/app/(public)/case-studies/[slug]/CaseStudyDetailClient.tsx
@@ -22,7 +22,7 @@ export default function CaseStudyDetailClient({ item }: { item: CaseStudy }) {
         {item.images.length > 0 && (
           <div className={styles.gallery}>
             {item.images.sort((a, b) => a.order - b.order).map((img, i) => (
-              <Image key={i} src={img.url} alt={img.alt} className={styles.galleryImg} width={1200} height={675} />
+              <Image key={i} src={img.url} alt={img.alt} className={styles.galleryImg} width={1200} height={675} sizes="(min-width: 640px) 50vw, 100vw" />
             ))}
           </div>
         )}

--- a/app/(public)/case-studies/[slug]/page.module.css
+++ b/app/(public)/case-studies/[slug]/page.module.css
@@ -3,7 +3,6 @@
 .back { display: inline-block; margin-bottom: var(--space-8); transition: color var(--transition-fast); }
 .back:hover { color: var(--color-text); }
 .header { display: flex; flex-direction: column; gap: var(--space-5); margin-bottom: var(--space-12); }
-.title { }
 .stack { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .tag { padding: var(--space-1) var(--space-3); background: var(--color-accent-muted); color: var(--color-accent); font-size: var(--text-sm); font-weight: var(--font-medium); border-radius: var(--radius-full); }
 .gallery { display: grid; grid-template-columns: 1fr; gap: var(--space-4); margin-bottom: var(--space-12); }
@@ -41,7 +40,7 @@
 .ctaBtn {
   display: inline-flex; align-items: center;
   padding: var(--space-3) var(--space-8);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-semibold); border-radius: var(--radius-full);
   transition: opacity var(--transition-fast), transform var(--transition-fast);

--- a/app/(public)/case-studies/page.tsx
+++ b/app/(public)/case-studies/page.tsx
@@ -13,7 +13,7 @@ export default async function CaseStudiesPage() {
   const items = await getPublishedCaseStudiesRest().catch(() => []);
 
   return (
-    <div className="section">
+    <section className="section">
       <div className="container">
         <p className="text-overline">Our Work</p>
         <h1 className={`text-headline ${styles.title}`}>Case Studies</h1>
@@ -43,6 +43,6 @@ export default async function CaseStudiesPage() {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/(public)/contact/page.module.css
+++ b/app/(public)/contact/page.module.css
@@ -1,6 +1,5 @@
 .inner { max-width: var(--container-sm); }
 .header { display: flex; flex-direction: column; gap: var(--space-4); margin-bottom: var(--space-12); }
-.title { }
 .form { display: flex; flex-direction: column; gap: var(--space-6); }
 .row { display: grid; grid-template-columns: 1fr; gap: var(--space-6); }
 @media (min-width: 640px) { .row { grid-template-columns: repeat(2, 1fr); } }
@@ -23,7 +22,7 @@
 .submit {
   display: inline-flex; align-items: center; justify-content: center;
   padding: var(--space-4) var(--space-10);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-size: var(--text-base); font-weight: var(--font-semibold);
   border-radius: var(--radius-full); border: none; cursor: pointer;
@@ -35,4 +34,4 @@
 .submit:hover:not(:disabled) { opacity: 0.9; transform: translateY(-1px); box-shadow: 0 6px 20px rgba(37, 99, 235, 0.4); }
 .submit:disabled { opacity: 0.6; cursor: not-allowed; }
 .success { display: flex; flex-direction: column; gap: var(--space-4); padding: var(--space-8); background: var(--color-success-muted); border-radius: var(--radius-xl); border: 1px solid var(--color-success); }
-.errorMsg { font-size: var(--text-sm); color: var(--color-error); padding: var(--space-3) var(--space-4); background: var(--color-error-muted); border-radius: var(--radius-md); }
+.errorMsg { font-size: var(--text-sm); color: var(--color-danger); padding: var(--space-3) var(--space-4); background: var(--color-danger-muted); border-radius: var(--radius-md); }

--- a/app/(public)/page.module.css
+++ b/app/(public)/page.module.css
@@ -51,7 +51,7 @@
   background-clip: text;
 }
 
-.sub { max-width: 600px; }
+.sub { max-width: var(--container-sm); }
 
 .heroCtas {
   display: flex;
@@ -64,7 +64,7 @@
   display: inline-flex;
   align-items: center;
   padding: var(--space-3) var(--space-8);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-semibold);
   border-radius: var(--radius-full);
@@ -146,7 +146,6 @@
   color: var(--color-accent);
 }
 
-.processTitle { }
 
 .processLink {
   margin-top: var(--space-8);
@@ -255,7 +254,7 @@
 
 /* ── CTA Banner ───────────────────────────────────────────── */
 .ctaBanner {
-  background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  background: linear-gradient(135deg, var(--color-surface-dark) 0%, var(--color-surface-dark-raised) 100%);
   padding-top: var(--space-20);
   padding-bottom: var(--space-20);
 }
@@ -277,7 +276,7 @@
   display: inline-flex;
   align-items: center;
   padding: var(--space-3) var(--space-8);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-semibold);
   border-radius: var(--radius-full);

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -116,7 +116,7 @@ export default async function HomePage() {
               {caseStudies.map(c => (
                 <Link key={c.id} href={`/case-studies/${c.slug}`} className={styles.caseCard}>
                   {c.images?.[0] && (
-                    <Image src={c.images[0].url} alt={c.images[0].alt} className={styles.caseImg} width={600} height={400} />
+                    <Image src={c.images[0].url} alt={c.images[0].alt} className={styles.caseImg} width={600} height={400} sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw" />
                   )}
                   <div className={styles.caseBody}>
                     <p className="text-caption text-muted">{c.industry}</p>

--- a/app/(public)/process/page.module.css
+++ b/app/(public)/process/page.module.css
@@ -5,7 +5,7 @@
 
 .title { margin-top: var(--space-3); margin-bottom: var(--space-5); }
 
-.intro { max-width: 600px; }
+.intro { max-width: var(--container-sm); }
 
 /* ── Steps ────────────────────────────────────────────────── */
 .steps {
@@ -61,7 +61,6 @@
   padding-bottom: var(--space-10);
 }
 
-.stepTitle { }
 
 /* ── CTA ──────────────────────────────────────────────────── */
 .cta {
@@ -78,7 +77,7 @@
   display: inline-flex;
   align-items: center;
   padding: var(--space-3) var(--space-8);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-semibold);
   border-radius: var(--radius-full);

--- a/app/(public)/process/page.tsx
+++ b/app/(public)/process/page.tsx
@@ -42,7 +42,7 @@ const STEPS = [
 
 export default function ProcessPage() {
   return (
-    <div className="section">
+    <section className="section">
       <div className="container">
         <div className={styles.header}>
           <p className="text-overline">How We Work</p>
@@ -73,6 +73,6 @@ export default function ProcessPage() {
           <Link href="/contact" className={styles.ctaBtn}>Start a Project →</Link>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/(public)/services/[slug]/page.module.css
+++ b/app/(public)/services/[slug]/page.module.css
@@ -43,7 +43,7 @@
 .ctaBtn {
   display: inline-flex; align-items: center;
   padding: var(--space-3) var(--space-8);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-semibold); border-radius: var(--radius-full);
   transition: opacity var(--transition-fast), transform var(--transition-fast);

--- a/app/(public)/services/page.module.css
+++ b/app/(public)/services/page.module.css
@@ -4,6 +4,7 @@
 .grid {
   margin-top: var(--space-4);
   counter-reset: service-count;
+  align-items: stretch;
 }
 
 .cardSkeleton { height: 280px; border-radius: var(--radius-xl); }
@@ -29,7 +30,14 @@
 }
 .card:hover { border-color: var(--color-accent); box-shadow: var(--shadow-md); transform: translateY(-2px); }
 
-.summary { flex: 1; }
+.summary {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cta { margin-top: auto; }
 
 .bullets {
   display: flex;

--- a/app/(public)/services/page.tsx
+++ b/app/(public)/services/page.tsx
@@ -12,7 +12,7 @@ export default async function ServicesPage() {
   const services = await getPublishedServicesRest();
 
   return (
-    <div className="section">
+    <section className="section">
       <div className="container">
         <p className="text-overline">What We Do</p>
         <h1 className={`text-headline ${styles.title}`}>Services</h1>
@@ -31,12 +31,12 @@ export default async function ServicesPage() {
                     {s.bullets.slice(0, 3).map((b, i) => <li key={i} className="text-body-sm">{b}</li>)}
                   </ul>
                 )}
-                <span className="text-label text-accent">Learn more →</span>
+                <span className={`text-label text-accent ${styles.cta}`}>Learn more →</span>
               </Link>
             ))}
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,10 @@ export const metadata: Metadata = {
     siteName: "TechByBrewski",
     type: "website",
     locale: "en_US",
+    title: "TechByBrewski — Custom Software & Firebase Solutions",
+    description: "TechByBrewski builds custom web applications, internal tools, and Firebase-powered systems for growing businesses.",
+    url: "https://techbybrewski.com",
+    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "TechByBrewski" }],
   },
 };
 

--- a/components/public/Footer/Footer.module.css
+++ b/components/public/Footer/Footer.module.css
@@ -1,74 +1,78 @@
 .footer {
-  background: #0f172a;
-  border-top: none;
+  background: var(--color-surface-dark);
   margin-top: auto;
 }
 
 .inner {
+  padding-top: var(--space-10);
+  padding-bottom: var(--space-8);
   display: flex;
   flex-direction: column;
   gap: var(--space-8);
-  padding-top: var(--space-12);
-  padding-bottom: var(--space-8);
 }
 
-@media (min-width: 640px) {
-  .inner { flex-direction: row; justify-content: space-between; align-items: flex-start; }
-}
-
-.brand { display: flex; flex-direction: column; gap: var(--space-3); }
-
-.logo {
-  font-family: var(--font-heading);
-  font-weight: var(--font-bold);
-  font-size: var(--text-lg);
-  color: #ffffff;
-}
-
-.tagline { color: rgba(255, 255, 255, 0.5); }
-
-.socials {
+/* ── Top row: brand + nav ─────────────────────────────────── */
+.top {
   display: flex;
-  gap: var(--space-4);
-}
-
-.social {
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: rgba(255, 255, 255, 0.5);
-  transition: color var(--transition-fast);
-}
-.social:hover { color: #ffffff; }
-
-.links {
-  display: flex;
-  flex-direction: row;
+  flex-direction: column;
   gap: var(--space-6);
 }
 
-.link {
+@media (min-width: 640px) {
+  .top {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.brand {
+  font-family: var(--font-heading);
+  font-weight: var(--font-bold);
+  font-size: var(--text-lg);
+  color: var(--color-text-inverse);
+  letter-spacing: var(--tracking-tight);
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-6);
+}
+
+.navLink {
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.55);
   transition: color var(--transition-fast);
 }
-.link:hover { color: #ffffff; }
+.navLink:hover { color: var(--color-text-inverse); }
 
+/* ── Bottom row: copyright + socials ─────────────────────── */
 .bottom {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-3);
-  padding-top: var(--space-4);
-  padding-bottom: var(--space-6);
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  gap: var(--space-4);
+  padding-top: var(--space-6);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.copyright { color: rgba(255, 255, 255, 0.35); }
+.copy {
+  font-size: var(--text-sm);
+  color: rgba(255, 255, 255, 0.3);
+}
 
-.emailLink {
-  color: rgba(255, 255, 255, 0.5);
+.socials {
+  display: flex;
+  gap: var(--space-5);
+}
+
+.social {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: rgba(255, 255, 255, 0.45);
   transition: color var(--transition-fast);
 }
-.emailLink:hover { color: var(--color-accent); }
+.social:hover { color: var(--color-text-inverse); }

--- a/components/public/Footer/Footer.tsx
+++ b/components/public/Footer/Footer.tsx
@@ -4,53 +4,49 @@ import Link from "next/link";
 import { useSiteSettings } from "@/lib/context/SiteSettingsContext";
 import styles from "./Footer.module.css";
 
+const NAV_LINKS = [
+  { label: "Services", href: "/services" },
+  { label: "Work", href: "/case-studies" },
+  { label: "Process", href: "/process" },
+  { label: "About", href: "/about" },
+  { label: "Contact", href: "/contact" },
+];
+
 export default function Footer() {
   const settings = useSiteSettings();
 
   return (
     <footer className={styles.footer}>
       <div className={`container ${styles.inner}`}>
-        <div className={styles.brand}>
-          <span className={styles.logo}>{settings?.brandName || "TechByBrewski"}</span>
-          <p className={`text-body-sm ${styles.tagline}`}>
-            {settings?.tagline || "Custom software & Firebase solutions for growing businesses."}
+        <div className={styles.top}>
+          <Link href="/" className={styles.brand}>
+            {settings?.brandName || "TechByBrewski"}
+          </Link>
+          <nav className={styles.nav} aria-label="Footer navigation">
+            {NAV_LINKS.map(l => (
+              <Link key={l.href} href={l.href} className={styles.navLink}>{l.label}</Link>
+            ))}
+          </nav>
+        </div>
+
+        <div className={styles.bottom}>
+          <p className={styles.copy}>
+            © {new Date().getFullYear()} {settings?.brandName || "TechByBrewski"}. All rights reserved.
           </p>
-          {/* Social links */}
           {settings?.socialLinks && (
             <div className={styles.socials}>
               {settings.socialLinks.linkedin && (
-                <a href={settings.socialLinks.linkedin} target="_blank" rel="noopener noreferrer" className={styles.social} aria-label="LinkedIn">
-                  LinkedIn
-                </a>
+                <a href={settings.socialLinks.linkedin} target="_blank" rel="noopener noreferrer" className={styles.social} aria-label="LinkedIn">LinkedIn</a>
               )}
               {settings.socialLinks.github && (
-                <a href={settings.socialLinks.github} target="_blank" rel="noopener noreferrer" className={styles.social} aria-label="GitHub">
-                  GitHub
-                </a>
+                <a href={settings.socialLinks.github} target="_blank" rel="noopener noreferrer" className={styles.social} aria-label="GitHub">GitHub</a>
               )}
               {settings.socialLinks.instagram && (
-                <a href={settings.socialLinks.instagram} target="_blank" rel="noopener noreferrer" className={styles.social} aria-label="Instagram">
-                  Instagram
-                </a>
+                <a href={settings.socialLinks.instagram} target="_blank" rel="noopener noreferrer" className={styles.social} aria-label="Instagram">Instagram</a>
               )}
             </div>
           )}
         </div>
-        <nav className={styles.links}>
-          <Link href="/services" className={styles.link}>Services</Link>
-          <Link href="/case-studies" className={styles.link}>Work</Link>
-          <Link href="/contact" className={styles.link}>Contact</Link>
-        </nav>
-      </div>
-      <div className={`container ${styles.bottom}`}>
-        <p className={`text-caption ${styles.copyright}`}>
-          © {new Date().getFullYear()} {settings?.brandName || "TechByBrewski"}. All rights reserved.
-        </p>
-        {settings?.contactEmail && (
-          <a href={`mailto:${settings.contactEmail}`} className={`text-caption ${styles.emailLink}`}>
-            {settings.contactEmail}
-          </a>
-        )}
       </div>
     </footer>
   );

--- a/components/public/Navbar/Navbar.module.css
+++ b/components/public/Navbar/Navbar.module.css
@@ -62,7 +62,7 @@
   display: inline-flex;
   align-items: center;
   padding: var(--space-2) var(--space-5);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
@@ -123,7 +123,7 @@
   justify-content: center;
   margin-top: var(--space-2);
   padding: var(--space-3);
-  background: linear-gradient(135deg, var(--color-accent), #3b82f6);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: var(--color-text-inverse);
   font-weight: var(--font-medium);
   border-radius: var(--radius-md);

--- a/components/public/Navbar/Navbar.tsx
+++ b/components/public/Navbar/Navbar.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useSiteSettings } from "@/lib/context/SiteSettingsContext";
 import styles from "./Navbar.module.css";
 
 const NAV_LINKS = [
@@ -14,12 +15,13 @@ const NAV_LINKS = [
 export default function Navbar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const settings = useSiteSettings();
 
   return (
     <header className={styles.header}>
       <nav className={`container ${styles.nav}`}>
         <Link href="/" className={styles.logo} onClick={() => setOpen(false)}>
-          TechByBrewski
+          {settings?.brandName || "TechByBrewski"}
         </Link>
 
         {/* Desktop links */}
@@ -31,7 +33,7 @@ export default function Navbar() {
         </div>
 
         {/* Mobile hamburger */}
-        <button className={styles.hamburger} onClick={() => setOpen(o => !o)} aria-label="Toggle menu">
+        <button className={styles.hamburger} onClick={() => setOpen(o => !o)} aria-label="Toggle menu" aria-expanded={open} aria-controls="mobile-nav">
           <span className={`${styles.bar} ${open ? styles.barTop : ""}`} />
           <span className={`${styles.bar} ${open ? styles.barMid : ""}`} />
           <span className={`${styles.bar} ${open ? styles.barBot : ""}`} />
@@ -40,7 +42,7 @@ export default function Navbar() {
 
       {/* Mobile menu */}
       {open && (
-        <div className={styles.mobileMenu}>
+        <div id="mobile-nav" className={styles.mobileMenu}>
           {NAV_LINKS.map(l => (
             <Link key={l.href} href={l.href} className={styles.mobileLink} onClick={() => setOpen(false)}>{l.label}</Link>
           ))}

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -120,3 +120,12 @@
 .transition-all  { transition: all var(--transition-base); }
 .transition-fast { transition: all var(--transition-fast); }
 .transition-slow { transition: all var(--transition-slow); }
+
+/* --- Reduced motion --- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,7 @@
   --color-primary-hover: #1a1a1a;
   --color-accent: #2563eb;
   --color-accent-hover: #1d4ed8;
+  --color-accent-light: #3b82f6;
   --color-accent-muted: #eff6ff;
 
   /* --- Surfaces --- */
@@ -24,6 +25,10 @@
   --color-text-subtle: #94a3b8;
   --color-text-inverse: #ffffff;
   --color-text-accent: #2563eb;
+
+  /* --- Dark surfaces --- */
+  --color-surface-dark: #0f172a;
+  --color-surface-dark-raised: #1e293b;
 
   /* --- Status --- */
   --color-success: #16a34a;
@@ -189,4 +194,11 @@ p {
 code,
 pre {
   font-family: var(--font-mono);
+}
+
+/* --- Focus --- */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
 }


### PR DESCRIPTION
## Summary
- Navbar now pulls brand name dynamically from SiteSettings context
- Footer restructured: full nav links in top row, socials + copyright in bottom row
- Added dark surface CSS tokens (`--color-surface-dark`, `--color-surface-dark-raised`) and `--color-accent-light`
- Added global `focus-visible` ring for keyboard a11y
- Added `prefers-reduced-motion` override in animations.css
- Public page images now include responsive `sizes` attribute where missing
- Minor CSS refinements across all public page modules

## Test plan
- [ ] Verify Navbar shows brand name from Firestore siteSettings
- [ ] Verify Footer nav links all route correctly
- [ ] Check focus ring appears on keyboard navigation
- [ ] Verify no layout regressions on mobile/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)