### PR TITLE
Design pass: refine brand fonts and color palette

### DIFF
--- a/app/(public)/page.module.css
+++ b/app/(public)/page.module.css
@@ -10,9 +10,7 @@
   content: "";
   position: absolute;
   inset: 0;
-  background:
-    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(79, 70, 229, 0.10) 0%, transparent 70%),
-    radial-gradient(ellipse 40% 30% at 80% 20%, rgba(249, 115, 22, 0.04) 0%, transparent 60%);
+  background: radial-gradient(ellipse 80% 60% at 50% -10%, rgba(79, 70, 229, 0.10) 0%, transparent 70%);
   pointer-events: none;
 }
 
@@ -47,7 +45,7 @@
 
 .headline {
   letter-spacing: var(--tracking-tight);
-  background: linear-gradient(135deg, #334155 30%, var(--color-accent) 100%);
+  background: linear-gradient(135deg, var(--color-slate-700) 30%, var(--color-accent) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import "@/styles/animations.css";
 const inter = Inter({
   subsets: ["latin"],
   variable: "--inter",
+  weight: ["400", "500", "600"],
   display: "swap",
 });
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,6 +18,7 @@
   --color-surface-raised: #f5f5f4;
   --color-border: #e7e5e4;
   --color-border-strong: #d6d3d1;
+  --color-surface-warm: #fdf8f0;
 
   /* --- Text --- */
   --color-text: #18181b;
@@ -29,6 +30,8 @@
   /* --- Dark surfaces --- */
   --color-surface-dark: #0f172a;
   --color-surface-dark-raised: #1e293b;
+
+  /* --- Neutrals --- */
   --color-slate-700: #334155;
 
   /* --- Status --- */
@@ -111,7 +114,6 @@
   --shadow-accent: 0 4px 14px rgba(79, 70, 229, 0.25);
   --shadow-accent-lg: 0 6px 20px rgba(79, 70, 229, 0.35);
   --shadow-accent-xl: 0 4px 14px rgba(79, 70, 229, 0.3);
-  --color-surface-warm: #fdf8f0;
   --shadow-warm-sm: 0 1px 3px 0 rgb(120 80 40 / 0.06), 0 1px 2px -1px rgb(120 80 40 / 0.04);
 
   /* --- Transitions --- */

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -82,7 +82,7 @@
   font-weight: var(--font-semibold);
   letter-spacing: var(--tracking-widest);
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 
 /* --- Color modifiers --- */


### PR DESCRIPTION
Closes #12

## What

- **globals.css reorganization**: Moved `--color-surface-warm` into the Surfaces block, `--color-slate-700` into a new dedicated Neutrals section, and `--shadow-warm-sm` stays in the Shadows block. All three were previously orphaned/out-of-order at the bottom of the Shadows section.
- **Typography token fix**: Replaced hardcoded `#64748b` in `.text-overline` with `var(--color-text-muted)` — now consistent with the token system.
- **Hero gradient cleanup**: Replaced hardcoded `#334155` in the homepage headline gradient with `var(--color-slate-700)`. Removed the near-invisible orange bleed (`rgba(249, 115, 22, 0.04)`) which had no CSS token backing and was inconsistent with the brand palette.
- **Font loader consistency**: Added explicit `weight: ["400", "500", "600"]` to the Inter font loader in `layout.tsx`, matching the Plus Jakarta Sans declaration pattern.

## Agent

Worked by: website agent

---
Generated by BrewCortex worker agent