### PR TITLE
chore: gitignore .claude/ directory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "permissions": {
-    "defaultMode": "bypassPermissions"
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ next-env.d.ts
 # OS
 .DS_Store
 
+# claude code
+.claude/
+
 # seed script credentials - NEVER COMMIT
 scripts/service-account.json
 firebase-debug.log


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore`
- Removes `.claude/settings.json` from tracking (personal Claude Code config)
- BrewCortex install script generates these directories — they don't belong in the repo

## Test plan
- [ ] Verify `.claude/` no longer appears on main after merge
- [ ] Verify local `.claude/` directory is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)