### PR TITLE
fix: return 403 for non-admin tokens in set-claims route

### DIFF
--- a/app/api/admin/set-claims/route.ts
+++ b/app/api/admin/set-claims/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
   try {
     const decoded = await adminAuth.verifyIdToken(idToken);
     if (!decoded.admin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 401 });
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const { uid, claims } = await req.json();


### PR DESCRIPTION
## Bug

The `POST /api/admin/set-claims` route was returning **401 Unauthorized** when a valid but non-admin token was presented. HTTP 401 signals that the request is unauthenticated (no/invalid credentials). A valid token that lacks the required `admin` claim should produce **403 Forbidden** instead.

## Root Cause

In `app/api/admin/set-claims/route.ts`, the guard branch after `verifyIdToken` succeeds but `decoded.admin` is falsy was returning `{ status: 401 }`. The `catch` block — which fires when `verifyIdToken` throws due to a missing or invalid token — already returns 401 correctly.

## Fix

Changed the `!decoded.admin` branch response from `401` to `403`. One-line diff.

## Auth flow after fix

| Scenario | Status |
|---|---|
| No token / invalid token | 401 Unauthorized |
| Valid token, not admin | 403 Forbidden |
| Valid admin token | 200 OK |