### PR TITLE
feat(portal): real-time unread message badges

### DIFF
--- a/app/admin/clients/page.tsx
+++ b/app/admin/clients/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { getAllClients } from "@/lib/firestore/portalQueries";
+import { getAllClients, subscribeToAdminUnreadCounts } from "@/lib/firestore/portalQueries";
 import { Client } from "@/lib/types";
 import { Button, Badge, Card } from "@/components/ui";
 import styles from "@/styles/adminList.module.css";
@@ -15,9 +15,15 @@ const STATUS_VARIANT: Record<Client["status"], "published" | "draft" | "neutral"
 export default function AdminClientsPage() {
   const [items, setItems] = useState<Client[]>([]);
   const [loading, setLoading] = useState(true);
+  const [unreadCounts, setUnreadCounts] = useState<Record<string, number>>({});
 
   useEffect(() => {
     getAllClients().then(setItems).finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const unsub = subscribeToAdminUnreadCounts(setUnreadCounts);
+    return unsub;
   }, []);
 
   return (
@@ -56,7 +62,12 @@ export default function AdminClientsPage() {
               className={styles.item}
             >
               <div className={styles.itemMain}>
-                <span className="text-body font-semibold">{c.companyName}</span>
+                <span className="text-body font-semibold">
+                  {c.companyName}
+                  {(unreadCounts[c.id] ?? 0) > 0 && (
+                    <span className={styles.unreadDot} aria-label={`${unreadCounts[c.id]} unread messages`} />
+                  )}
+                </span>
                 <span className="text-body-sm text-muted">
                   {c.contactName} · {c.email}
                 </span>

--- a/app/admin/clients/view/page.tsx
+++ b/app/admin/clients/view/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import {
   getClient,
   getClientDocuments,
+  subscribeToClientUnreadForAdmin,
   getClientContracts,
   getClientInvoices,
 } from "@/lib/firestore/portalQueries";
@@ -52,6 +53,7 @@ export default function AdminClientViewPage() {
   const [client, setClient] = useState<Client | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<Tab>("documents");
+  const [messagesUnread, setMessagesUnread] = useState(0);
 
   useEffect(() => {
     if (!clientId) return;
@@ -59,6 +61,12 @@ export default function AdminClientViewPage() {
       .then(setClient)
       .catch(console.error)
       .finally(() => setLoading(false));
+  }, [clientId]);
+
+  useEffect(() => {
+    if (!clientId) return;
+    const unsub = subscribeToClientUnreadForAdmin(clientId, setMessagesUnread);
+    return unsub;
   }, [clientId]);
 
   if (!clientId) {
@@ -105,6 +113,11 @@ export default function AdminClientViewPage() {
             onClick={() => setActiveTab(t.key)}
           >
             {t.label}
+            {t.key === "messages" && messagesUnread > 0 && (
+              <span className={styles.tabUnreadBadge} aria-label={`${messagesUnread} unread`}>
+                {messagesUnread > 99 ? "99+" : messagesUnread}
+              </span>
+            )}
           </button>
         ))}
       </div>

--- a/components/portal/ClientShell/ClientShell.module.css
+++ b/components/portal/ClientShell/ClientShell.module.css
@@ -270,3 +270,22 @@
     padding: var(--space-10);
   }
 }
+
+.navItemLabel {
+  flex: 1;
+}
+
+.unreadBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  line-height: 1;
+}

--- a/components/portal/ClientShell/ClientShell.tsx
+++ b/components/portal/ClientShell/ClientShell.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "firebase/auth";
 import { auth } from "@/lib/firebase";
+import { usePortalUser } from "@/components/portal/ClientAuthProvider/ClientAuthProvider";
+import { subscribeToUnreadMessageCount } from "@/lib/firestore/portalQueries";
 import styles from "./ClientShell.module.css";
 
-const NAV_ITEMS = [
+const BASE_NAV_ITEMS = [
   { label: "Dashboard", href: "/portal" },
   { label: "Documents", href: "/portal/documents" },
   { label: "Contracts", href: "/portal/contracts" },
@@ -22,18 +24,26 @@ export default function ClientShell({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const { clientId } = usePortalUser();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    const unsub = subscribeToUnreadMessageCount(clientId, setUnreadCount);
+    return unsub;
+  }, [clientId]);
 
   const closeDrawer = () => setDrawerOpen(false);
 
   const navContent = (
     <>
       <nav className={styles.nav}>
-        {NAV_ITEMS.map((item) => {
+        {BASE_NAV_ITEMS.map((item) => {
           const isActive =
             item.href === "/portal"
               ? pathname === "/portal"
               : pathname.startsWith(item.href);
+          const showBadge = item.href === "/portal/messages" && unreadCount > 0;
 
           return (
             <Link
@@ -42,7 +52,12 @@ export default function ClientShell({
               onClick={closeDrawer}
               className={`${styles.navItem} ${isActive ? styles.navItemActive : ""}`}
             >
-              {item.label}
+              <span className={styles.navItemLabel}>{item.label}</span>
+              {showBadge && (
+                <span className={styles.unreadBadge} aria-label={`${unreadCount} unread messages`}>
+                  {unreadCount > 99 ? "99+" : unreadCount}
+                </span>
+              )}
             </Link>
           );
         })}
@@ -114,7 +129,7 @@ export default function ClientShell({
         {navContent}
       </aside>
 
-      {/* Main content */}
+      {/* Main content area */}
       <main className={styles.main}>
         <div className={styles.content}>{children}</div>
       </main>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -4,49 +4,106 @@
       "collectionGroup": "services",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "isPublished", "order": "ASCENDING" },
-        { "fieldPath": "order", "order": "ASCENDING" }
+        {
+          "fieldPath": "isPublished",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "order",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "caseStudies",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "isPublished", "order": "ASCENDING" },
-        { "fieldPath": "order", "order": "ASCENDING" }
+        {
+          "fieldPath": "isPublished",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "order",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "caseStudies",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "isPublished", "order": "ASCENDING" },
-        { "fieldPath": "featured", "order": "ASCENDING" },
-        { "fieldPath": "order", "order": "ASCENDING" }
+        {
+          "fieldPath": "isPublished",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "featured",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "order",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "caseStudies",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "isPublished", "order": "ASCENDING" },
-        { "fieldPath": "publishedAt", "order": "DESCENDING" }
+        {
+          "fieldPath": "isPublished",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "publishedAt",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "testimonials",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "isPublished", "order": "ASCENDING" },
-        { "fieldPath": "order", "order": "ASCENDING" }
+        {
+          "fieldPath": "isPublished",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "order",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "faqs",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "isPublished", "order": "ASCENDING" },
-        { "fieldPath": "order", "order": "ASCENDING" }
+        {
+          "fieldPath": "isPublished",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "order",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "isRead",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "senderRole",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
       ]
     }
   ],

--- a/lib/firestore/portalQueries.ts
+++ b/lib/firestore/portalQueries.ts
@@ -1,12 +1,14 @@
 "use client";
 import {
   collection,
+  collectionGroup,
   doc,
   getDoc,
   getDocs,
   query,
   orderBy,
   onSnapshot,
+  where,
   Unsubscribe,
 } from "firebase/firestore";
 import { db } from "@/lib/firebase";
@@ -80,5 +82,67 @@ export function subscribeToMessages(
   );
   return onSnapshot(q, (snap) => {
     callback(snap.docs.map((d) => withId<ClientMessage>(d.id, d.data())));
+  });
+}
+
+// ── Unread message counts ──────────────────────────────────────
+
+/**
+ * Portal: subscribe to unread messages sent by admin for a given client.
+ * Used in ClientShell to show badge on Messages nav item.
+ */
+export function subscribeToUnreadMessageCount(
+  clientId: string,
+  callback: (count: number) => void
+): Unsubscribe {
+  const q = query(
+    collection(db, "clients", clientId, "messages"),
+    where("isRead", "==", false),
+    where("senderRole", "==", "admin")
+  );
+  return onSnapshot(q, (snap) => callback(snap.size));
+}
+
+/**
+ * Admin (single client): subscribe to unread messages sent by this client.
+ * Used in admin client view to show badge on Messages tab.
+ */
+export function subscribeToClientUnreadForAdmin(
+  clientId: string,
+  callback: (count: number) => void
+): Unsubscribe {
+  const q = query(
+    collection(db, "clients", clientId, "messages"),
+    where("isRead", "==", false),
+    where("senderRole", "==", "client")
+  );
+  return onSnapshot(q, (snap) => callback(snap.size));
+}
+
+/**
+ * Admin (all clients): subscribe to unread client message counts across all clients.
+ * Uses a COLLECTION_GROUP query on "messages".
+ * Returns map of clientId -> unread count (only clients with > 0 unread).
+ * Requires composite COLLECTION_GROUP index: isRead ASC + senderRole ASC + createdAt DESC.
+ */
+export function subscribeToAdminUnreadCounts(
+  callback: (counts: Record<string, number>) => void
+): Unsubscribe {
+  const q = query(
+    collectionGroup(db, "messages"),
+    where("isRead", "==", false),
+    where("senderRole", "==", "client"),
+    orderBy("createdAt", "desc")
+  );
+  return onSnapshot(q, (snap) => {
+    const counts: Record<string, number> = {};
+    snap.docs.forEach((d) => {
+      // Path: clients/{clientId}/messages/{messageId}
+      const clientId = d.ref.parent.parent?.id;
+      if (clientId) {
+        counts[clientId] = (counts[clientId] ?? 0) + 1;
+      }
+    });
+    callback(counts);
   });
 }

--- a/styles/adminList.module.css
+++ b/styles/adminList.module.css
@@ -8,3 +8,13 @@
 .itemMeta { display: flex; align-items: center; gap: var(--space-3); }
 .listPending { opacity: 0.7; pointer-events: none; }
 .errorMsg { font-size: var(--text-sm); color: var(--color-danger); padding: var(--space-3) var(--space-4); background: var(--color-error-muted, #fef2f2); border-radius: var(--radius-md); border: 1px solid var(--color-danger); }
+
+.unreadDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-left: var(--space-2);
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  vertical-align: middle;
+}

--- a/styles/portal.module.css
+++ b/styles/portal.module.css
@@ -76,3 +76,19 @@
   border-radius: var(--radius-md);
   border: 1px solid var(--color-danger);
 }
+
+.tabUnreadBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  margin-left: var(--space-2);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: var(--font-semibold);
+  line-height: 1;
+}


### PR DESCRIPTION
Closes #18

## What

- **`lib/firestore/portalQueries.ts`** — Three new real-time `onSnapshot` subscriptions:
  - `subscribeToUnreadMessageCount(clientId)` — counts admin-sent unread messages for portal badge
  - `subscribeToClientUnreadForAdmin(clientId)` — counts client-sent unread messages for admin tab badge
  - `subscribeToAdminUnreadCounts()` — collection group query across all clients for admin list dots

- **`firestore.indexes.json`** — Adds `COLLECTION_GROUP` composite index on `messages` (`isRead ASC + senderRole ASC + createdAt DESC`). **Must be deployed (`firebase deploy --only firestore:indexes`) before the feature goes live** — emulators auto-create indexes for local testing.

- **`ClientShell.tsx` + `ClientShell.module.css`** — Portal nav subscribes to unread count on mount; Messages nav item shows a numbered badge when count > 0.

- **`app/admin/clients/view/page.tsx`** — Admin client view subscribes to per-client unread count; Messages tab button shows numbered badge.

- **`app/admin/clients/page.tsx`** — Admin clients list subscribes to aggregate unread counts; client rows show a small accent dot when they have unread messages.

- **`styles/portal.module.css`** + **`styles/adminList.module.css`** — Badge and dot styles using existing design tokens.

## Agent

Worked by: engineering agent (worker)

---
Generated by BrewCortex worker agent