### PR TITLE
Portal settings page (read-only profile)

### DIFF
--- a/app/portal/settings/page.tsx
+++ b/app/portal/settings/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePortalUser } from "@/components/portal/ClientAuthProvider/ClientAuthProvider";
+import { getClient } from "@/lib/firestore/portalQueries";
+import type { Client } from "@/lib/types";
+import styles from "@/styles/portal.module.css";
+import settingsStyles from "./settings.module.css";
+
+export default function PortalSettingsPage() {
+  const { clientId } = usePortalUser();
+  const [client, setClient] = useState<Client | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getClient(clientId)
+      .then(setClient)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [clientId]);
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h1 className={`text-h2 ${styles.headerTitle}`}>Settings</h1>
+      </div>
+
+      {loading ? (
+        <div className={styles.empty}>Loading…</div>
+      ) : !client ? (
+        <div className={styles.empty}>Profile not found.</div>
+      ) : (
+        <div className={settingsStyles.card}>
+          <h2 className={`text-label ${settingsStyles.sectionTitle}`}>Profile</h2>
+          <dl className={settingsStyles.fieldList}>
+            <ProfileField label="Name" value={client.contactName} />
+            <ProfileField label="Email" value={client.email} />
+            <ProfileField label="Company" value={client.companyName} />
+            <ProfileField
+              label="Services"
+              value={client.services.length > 0 ? client.services.join(", ") : "—"}
+            />
+            <ProfileField label="Status" value={client.status} />
+          </dl>
+          <p className={`text-body-sm ${settingsStyles.note}`}>
+            To update your profile, contact TechByBrewski directly.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProfileField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={settingsStyles.field}>
+      <dt className={`text-body-sm ${settingsStyles.fieldLabel}`}>{label}</dt>
+      <dd className={`text-body ${settingsStyles.fieldValue}`}>{value || "—"}</dd>
+    </div>
+  );
+}

--- a/app/portal/settings/settings.module.css
+++ b/app/portal/settings/settings.module.css
@@ -1,0 +1,46 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-6);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  max-width: 480px;
+}
+
+.sectionTitle {
+  font-weight: var(--font-semibold);
+  color: var(--color-text);
+}
+
+.fieldList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.fieldLabel {
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.fieldValue {
+  color: var(--color-text);
+}
+
+.note {
+  color: var(--color-text-muted);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}

--- a/components/portal/ClientShell/ClientShell.tsx
+++ b/components/portal/ClientShell/ClientShell.tsx
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { label: "Contracts", href: "/portal/contracts" },
   { label: "Messages", href: "/portal/messages" },
   { label: "Invoices", href: "/portal/invoices" },
+  { label: "Settings", href: "/portal/settings" },
 ];
 
 export default function ClientShell({


### PR DESCRIPTION
Closes #19

## What
- Adds `app/portal/settings/page.tsx` — a client component that fetches the authenticated user's Client doc via `getClient(clientId)` and displays contactName, email, companyName, services, and status in a read-only card layout
- Adds `app/portal/settings/settings.module.css` — colocated CSS using existing design tokens (CSS variables, portal layout classes)
- Adds "Settings" to `NAV_ITEMS` in `ClientShell` so the page is reachable from portal navigation on both desktop sidebar and mobile drawer

No edit capability — clients are instructed to contact TechByBrewski to update their profile (admin manages client data).

## Agent
Worked by: engineering agent (worker)

---
Generated by BrewCortex worker agent