### PR TITLE
Test Firestore security rules via emulator

### DIFF
--- a/firestore/__tests__/firestore.rules.test.ts
+++ b/firestore/__tests__/firestore.rules.test.ts
@@ -251,3 +251,131 @@ describe("Admin access", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Public collections — isPublished gating
+// ---------------------------------------------------------------------------
+
+describe("Public collections — isPublished gating", () => {
+  const PUBLIC_COLLECTIONS = ["services", "caseStudies", "testimonials", "faqs"];
+
+  for (const col of PUBLIC_COLLECTIONS) {
+    it(`denies unauthenticated read of unpublished ${col} document`, async () => {
+      // Given: an unpublished document exists
+      await seed(`${col}/doc-1`, { isPublished: false, name: "Hidden" });
+
+      // When: unauthenticated user reads it
+      // Then: read is denied
+      await assertFails(getDoc(doc(unauthed(), `${col}/doc-1`)));
+    });
+
+    it(`allows admin to read unpublished ${col} document`, async () => {
+      // Given: an unpublished document exists
+      await seed(`${col}/doc-1`, { isPublished: false, name: "Hidden" });
+
+      // When: admin reads it
+      // Then: read is allowed (admin bypasses isPublished check)
+      await assertSucceeds(getDoc(doc(asAdmin("admin-1"), `${col}/doc-1`)));
+    });
+
+    it(`allows admin to write to ${col}`, async () => {
+      // Given: admin context
+      // When: admin creates a document
+      // Then: write is allowed
+      await assertSucceeds(
+        setDoc(doc(asAdmin("admin-1"), `${col}/new-doc`), {
+          isPublished: false,
+          name: "Draft",
+        })
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// contactSubmissions — public read denied
+// ---------------------------------------------------------------------------
+
+describe("contactSubmissions — access control", () => {
+  it("denies unauthenticated read of contactSubmissions", async () => {
+    // Given: a contact submission exists
+    await seed("contactSubmissions/sub-1", {
+      name: "Visitor",
+      email: "v@example.com",
+    });
+
+    // When: unauthenticated user reads it
+    // Then: read is denied
+    await assertFails(
+      getDoc(doc(unauthed(), "contactSubmissions/sub-1"))
+    );
+  });
+
+  it("allows admin to read contactSubmissions", async () => {
+    // Given: a contact submission exists
+    await seed("contactSubmissions/sub-1", {
+      name: "Visitor",
+      email: "v@example.com",
+    });
+
+    // When: admin reads it
+    // Then: read is allowed
+    await assertSucceeds(
+      getDoc(doc(asAdmin("admin-1"), "contactSubmissions/sub-1"))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client portal — messages and invoice write restrictions
+// ---------------------------------------------------------------------------
+
+describe("Client portal — subcollection access", () => {
+  it("allows a client to create a message in their own subcollection", async () => {
+    // Given: client1 is authenticated
+    // When: they create a message in clients/client1/messages
+    // Then: write succeeds
+    await assertSucceeds(
+      addDoc(
+        collection(asClient("client1"), "clients/client1/messages"),
+        { body: "Hello admin", senderRole: "client" }
+      )
+    );
+  });
+
+  it("denies a client writing to their own invoices subcollection", async () => {
+    // Given: client1 is authenticated
+    // When: they attempt to write an invoice in clients/client1/invoices
+    // Then: write is denied (clients can only read invoices, not write)
+    await assertFails(
+      setDoc(doc(asClient("client1"), "clients/client1/invoices/inv-fake"), {
+        amountCents: 0,
+        status: "draft",
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default deny — unmatched paths
+// ---------------------------------------------------------------------------
+
+describe("Default deny", () => {
+  it("denies unauthenticated read of an undefined collection", async () => {
+    // Given: any user
+    // When: they access a path that matches no rule
+    // Then: access is denied
+    await assertFails(
+      getDoc(doc(unauthed(), "unknownCollection/some-doc"))
+    );
+  });
+
+  it("denies admin read of an undefined collection", async () => {
+    // Given: admin user
+    // When: they access an undefined collection path
+    // Then: access is still denied (admin has no blanket grant — only specific collections)
+    await assertFails(
+      getDoc(doc(asAdmin("admin-1"), "unknownCollection/some-doc"))
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "seed:emulator:force": "node scripts/seed-emulator.mjs --force",
     "dev:full": "concurrently 'npm run emulators' 'npm run dev'",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:rules": "firebase emulators:exec --only firestore --project techbybrewski-test \"FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 npx vitest run --config vitest.rules.config.ts\""
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["firestore/__tests__/**/*.test.ts"],
+    globals: true,
+  },
+});


### PR DESCRIPTION
Closes #41

## What

Completes the BDD acceptance criteria for Firestore security rules testing against the Firebase emulator using `@firebase/rules-unit-testing`.

Added missing test scenarios to `firestore/__tests__/firestore.rules.test.ts`:

- **Public collections** (services, caseStudies, testimonials, faqs): unauthenticated reads of unpublished docs are denied; admin can read/write regardless of publish status
- **contactSubmissions**: unauthenticated reads denied, admin reads allowed
- **Client portal**: clients can create messages in their own subcollection; clients cannot write to their own invoices subcollection
- **Default deny**: any user accessing an undefined collection path is denied (including admins — no blanket grant)

Also added `vitest.rules.config.ts` (dedicated config that includes `firestore/__tests__/**` which the default vitest config excludes) and a `test:rules` npm script for running the suite via the emulator.

All 31 tests pass.

## Agent

Worked by: worker agent (inline implementation)

---
Generated by BrewCortex worker agent