### PR TITLE
Blog data model and Firestore queries

### DIFF
--- a/lib/firestore/blog-rest.ts
+++ b/lib/firestore/blog-rest.ts
@@ -1,0 +1,60 @@
+/**
+ * Server-side blog post helpers using the Firebase Admin SDK.
+ * Follows the same patterns as rest.ts.
+ *
+ * DO NOT add "use client" — this file is server-only.
+ */
+
+import { adminDb } from "@/lib/firebase-admin";
+import type { BlogPost } from "@/lib/types";
+import type { DocumentData, QueryDocumentSnapshot } from "firebase-admin/firestore";
+
+// ── Shape helper ───────────────────────────────────────────────
+
+function toBlogPost(id: string, d: DocumentData): BlogPost {
+  return {
+    id,
+    title: (d.title as string) ?? "",
+    slug: (d.slug as string) ?? "",
+    excerpt: (d.excerpt as string) ?? "",
+    content: (d.content as string) ?? "",
+    coverImageUrl: (d.coverImageUrl as string | undefined),
+    tags: (d.tags as string[]) ?? [],
+    author: (d.author as string) ?? "",
+    isPublished: (d.isPublished as boolean) ?? false,
+    publishedAt: null,
+    createdAt: d.createdAt ?? null,
+    updatedAt: d.updatedAt ?? null,
+  };
+}
+
+// ── Public query helpers ───────────────────────────────────────
+
+export async function getPublishedBlogPostsRest(): Promise<BlogPost[]> {
+  const snap = await adminDb
+    .collection("blogPosts")
+    .where("isPublished", "==", true)
+    .orderBy("publishedAt", "desc")
+    .get();
+  return snap.docs.map((doc: QueryDocumentSnapshot) => toBlogPost(doc.id, doc.data()));
+}
+
+export async function getBlogPostBySlugRest(slug: string): Promise<BlogPost | null> {
+  const snap = await adminDb
+    .collection("blogPosts")
+    .where("isPublished", "==", true)
+    .where("slug", "==", slug)
+    .limit(1)
+    .get();
+  if (snap.empty) return null;
+  const doc = snap.docs[0];
+  return toBlogPost(doc.id, doc.data());
+}
+
+export async function getPublishedBlogPostSlugsRest(): Promise<string[]> {
+  const snap = await adminDb
+    .collection("blogPosts")
+    .where("isPublished", "==", true)
+    .get();
+  return snap.docs.map((doc: QueryDocumentSnapshot) => doc.data().slug as string).filter(Boolean);
+}

--- a/lib/firestore/mutations.ts
+++ b/lib/firestore/mutations.ts
@@ -17,6 +17,7 @@ import type {
   TestimonialFormData,
   FAQFormData,
   ActivityAction,
+  BlogPostFormData,
 } from "@/lib/types";
 
 // ── Activity Log ──────────────────────────────────────────────
@@ -178,4 +179,48 @@ export async function reorderTestimonials(items: { id: string; order: number }[]
 
 export async function reorderCaseStudies(items: { id: string; order: number }[]): Promise<void> {
   await reorderCollection("caseStudies", items);
+}
+
+// ── Blog Posts ─────────────────────────────────────────────────
+
+export async function createBlogPost(data: BlogPostFormData): Promise<string> {
+  const ref = await addDoc(collection(db, "blogPosts"), {
+    ...data,
+    isPublished: false,
+    publishedAt: null,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+  await log("CREATE", "blogPosts", ref.id, `Created blog post: ${data.title}`);
+  return ref.id;
+}
+
+export async function updateBlogPost(id: string, data: Partial<BlogPostFormData>): Promise<void> {
+  await updateDoc(doc(db, "blogPosts", id), {
+    ...data,
+    updatedAt: serverTimestamp(),
+  });
+  await log("UPDATE", "blogPosts", id, `Updated blog post: ${data.title ?? id}`);
+}
+
+export async function deleteBlogPost(id: string, title: string): Promise<void> {
+  await deleteDoc(doc(db, "blogPosts", id));
+  await log("DELETE", "blogPosts", id, `Deleted blog post: ${title}`);
+}
+
+export async function publishBlogPost(id: string, title: string, wasPublished: boolean): Promise<void> {
+  await updateDoc(doc(db, "blogPosts", id), {
+    isPublished: true,
+    updatedAt: serverTimestamp(),
+    ...(wasPublished ? {} : { publishedAt: serverTimestamp() }),
+  });
+  await log("PUBLISH", "blogPosts", id, `Published blog post: ${title}`);
+}
+
+export async function unpublishBlogPost(id: string, title: string): Promise<void> {
+  await updateDoc(doc(db, "blogPosts", id), {
+    isPublished: false,
+    updatedAt: serverTimestamp(),
+  });
+  await log("UNPUBLISH", "blogPosts", id, `Unpublished blog post: ${title}`);
 }

--- a/lib/firestore/queries.ts
+++ b/lib/firestore/queries.ts
@@ -18,6 +18,7 @@ import type {
   Testimonial,
   FAQ,
   ActivityLogEntry,
+  BlogPost,
 } from "@/lib/types";
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -214,4 +215,35 @@ export async function getDashboardStats(): Promise<DashboardStats> {
     testimonials: count(testimonials),
     faqs: count(faqs),
   };
+}
+
+// ── Blog Posts ─────────────────────────────────────────────────
+
+export async function getPublishedBlogPosts(): Promise<BlogPost[]> {
+  const q = query(
+    collection(db, "blogPosts"),
+    where("isPublished", "==", true),
+    orderBy("publishedAt", "desc")
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => withId<BlogPost>(d.id, d.data()));
+}
+
+export async function getBlogPostBySlug(slug: string): Promise<BlogPost | null> {
+  const q = query(
+    collection(db, "blogPosts"),
+    where("slug", "==", slug),
+    where("isPublished", "==", true),
+    limit(1)
+  );
+  const snap = await getDocs(q);
+  if (snap.empty) return null;
+  const d = snap.docs[0];
+  return withId<BlogPost>(d.id, d.data());
+}
+
+export async function getAllBlogPosts(): Promise<BlogPost[]> {
+  const q = query(collection(db, "blogPosts"), orderBy("createdAt", "desc"));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => withId<BlogPost>(d.id, d.data()));
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,3 +171,21 @@ export interface ClientInvoice {
   dueDate: FirestoreTimestamp | null;
   createdAt: FirestoreTimestamp;
 }
+
+// ── Blog Post ──────────────────────────────────────────────────
+export interface BlogPost {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string;        // Short summary for listing cards
+  content: string;        // Markdown body
+  coverImageUrl?: string;
+  tags: string[];
+  author: string;
+  isPublished: boolean;
+  publishedAt: FirestoreTimestamp | null;
+  createdAt: FirestoreTimestamp;
+  updatedAt: FirestoreTimestamp;
+}
+
+export type BlogPostFormData = Omit<BlogPost, "id" | "publishedAt" | "createdAt" | "updatedAt">;


### PR DESCRIPTION
Closes #48

## What

- Added `BlogPost` interface and `BlogPostFormData` type to `lib/types.ts`, using `FirestoreTimestamp` consistent with existing `CaseStudy` and `Client` types
- Added three queries to `lib/firestore/queries.ts`: `getPublishedBlogPosts` (ordered by `publishedAt` desc), `getBlogPostBySlug` (published only), `getAllBlogPosts` (admin, all statuses, ordered by `createdAt` desc)
- Added five mutations to `lib/firestore/mutations.ts`: `createBlogPost`, `updateBlogPost`, `deleteBlogPost`, `publishBlogPost`, `unpublishBlogPost` — all follow the existing `log()` activity pattern used by Service and CaseStudy
- Added `lib/firestore/blog-rest.ts` with Admin SDK server-side helpers (`getPublishedBlogPostsRest`, `getBlogPostBySlugRest`, `getPublishedBlogPostSlugsRest`) following `rest.ts` patterns

All implementations follow the Service/CaseStudy patterns exactly.

## Agent

Worked by: engineering agent (worker inline)

---
Generated by BrewCortex worker agent