### PR TITLE
Test InvoiceCard and FileUpload components

### DIFF
--- a/components/portal/FileUpload/FileUpload.test.tsx
+++ b/components/portal/FileUpload/FileUpload.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const {
+  mockRef,
+  mockUploadBytesResumable,
+  mockAddClientDocument,
+  mockAuth,
+} = vi.hoisted(() => {
+  const mockTask = { on: vi.fn(), snapshot: { ref: {} } };
+  return {
+    mockRef: vi.fn(() => ({})),
+    mockUploadBytesResumable: vi.fn(() => mockTask),
+    mockAddClientDocument: vi.fn(() => Promise.resolve("doc-id")),
+    mockAuth: {
+      currentUser: null as null | {
+        getIdTokenResult: () => Promise<{ claims: Record<string, unknown> }>;
+      },
+    },
+  };
+});
+
+vi.mock("firebase/storage", () => ({
+  ref: mockRef,
+  uploadBytesResumable: mockUploadBytesResumable,
+  getDownloadURL: vi.fn(() => Promise.resolve("https://cdn.example.com/file.pdf")),
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  storage: {},
+  auth: mockAuth,
+}));
+
+vi.mock("@/lib/firestore/portalMutations", () => ({
+  addClientDocument: mockAddClientDocument,
+}));
+
+vi.mock("./FileUpload.module.css", () => ({ default: {} }));
+
+import FileUpload from "./FileUpload";
+
+function makeFile(name: string, size: number, type = "application/pdf"): File {
+  const file = new File(["x"], name, { type });
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+describe("FileUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.currentUser = null;
+  });
+
+  it("renders the upload dropzone", () => {
+    // Given: the FileUpload component is mounted
+    // When: it renders
+    render(<FileUpload clientId="client-1" category="files" onComplete={vi.fn()} />);
+
+    // Then: an upload dropzone/button is visible
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByText(/choose a file/i)).toBeInTheDocument();
+  });
+
+  it("calls uploadBytesResumable when a valid file is selected by an authenticated user", () => {
+    // Given: a user is authenticated
+    mockAuth.currentUser = {
+      getIdTokenResult: () => Promise.resolve({ claims: { client: true } }),
+    };
+
+    render(<FileUpload clientId="client-1" category="files" onComplete={vi.fn()} />);
+
+    const input = document.querySelector("input[type='file']") as HTMLInputElement;
+
+    // When: the file input changes with a valid file
+    const file = makeFile("report.pdf", 1024);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // Then: uploadBytesResumable is invoked with the file
+    expect(mockUploadBytesResumable).toHaveBeenCalledWith(expect.anything(), file);
+  });
+
+  it("shows an error and does not upload when file exceeds 25 MB", () => {
+    // Given: the user is authenticated
+    mockAuth.currentUser = {
+      getIdTokenResult: () => Promise.resolve({ claims: { client: true } }),
+    };
+
+    render(<FileUpload clientId="client-1" category="files" onComplete={vi.fn()} />);
+
+    const input = document.querySelector("input[type='file']") as HTMLInputElement;
+
+    // When: a file larger than 25 MB is selected
+    const bigFile = makeFile("huge.zip", 26 * 1024 * 1024);
+    fireEvent.change(input, { target: { files: [bigFile] } });
+
+    // Then: an error message is shown
+    expect(screen.getByText(/file too large/i)).toBeInTheDocument();
+
+    // And: no upload was initiated
+    expect(mockUploadBytesResumable).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when no user is authenticated", () => {
+    // Given: no user is signed in (currentUser is null)
+    mockAuth.currentUser = null;
+
+    render(<FileUpload clientId="client-1" category="files" onComplete={vi.fn()} />);
+
+    const input = document.querySelector("input[type='file']") as HTMLInputElement;
+
+    // When: a file is selected
+    const file = makeFile("doc.pdf", 1024);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // Then: "Not authenticated." error is shown
+    expect(screen.getByText("Not authenticated.")).toBeInTheDocument();
+
+    // And: no upload was initiated
+    expect(mockUploadBytesResumable).not.toHaveBeenCalled();
+  });
+});

--- a/components/portal/InvoiceCard/InvoiceCard.test.tsx
+++ b/components/portal/InvoiceCard/InvoiceCard.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/Badge", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="badge">{children}</span>
+  ),
+}));
+
+vi.mock("./InvoiceCard.module.css", () => ({ default: {} }));
+
+import InvoiceCard from "./InvoiceCard";
+import type { ClientInvoice } from "@/lib/types";
+
+const base: ClientInvoice = {
+  id: "inv-1",
+  type: "one-time",
+  amountCents: 15000,
+  currency: "USD",
+  description: "Web project deposit",
+  status: "paid",
+  mercuryInvoiceId: null,
+  mercuryPaymentUrl: null,
+  paidAt: null,
+  dueDate: null,
+  createdAt: { seconds: 1700000000, nanoseconds: 0 },
+};
+
+describe("InvoiceCard", () => {
+  it("renders a paid invoice with paid badge and no pay button", () => {
+    // Given: an invoice with status "paid"
+    // When: InvoiceCard renders
+    render(<InvoiceCard invoice={{ ...base, status: "paid" }} />);
+
+    // Then: "Paid" badge is displayed
+    expect(screen.getByTestId("badge")).toHaveTextContent("Paid");
+
+    // And: no pay button is shown
+    expect(screen.queryByRole("link", { name: /pay/i })).toBeNull();
+  });
+
+  it("renders a pending invoice with pay button when showPayButton and payment URL exist", () => {
+    // Given: an invoice with status "pending" and a payment URL
+    const invoice: ClientInvoice = {
+      ...base,
+      status: "pending",
+      mercuryPaymentUrl: "https://pay.mercury.com/inv-1",
+    };
+
+    // When: InvoiceCard renders with showPayButton=true
+    render(<InvoiceCard invoice={invoice} showPayButton />);
+
+    // Then: "Pending" badge is displayed
+    expect(screen.getByTestId("badge")).toHaveTextContent("Pending");
+
+    // And: a pay button links to the payment URL
+    const link = screen.getByRole("link", { name: /pay/i });
+    expect(link).toHaveAttribute("href", "https://pay.mercury.com/inv-1");
+  });
+
+  it("renders an overdue invoice (status sent, past dueDate) with sent badge", () => {
+    // Given: an invoice with status "sent" and dueDate in the past
+    const invoice: ClientInvoice = {
+      ...base,
+      status: "sent",
+      dueDate: { seconds: 1000000000, nanoseconds: 0 }, // past date
+    };
+
+    // When: InvoiceCard renders
+    render(<InvoiceCard invoice={invoice} />);
+
+    // Then: a "Sent" badge is displayed (overdue indicator via badge)
+    expect(screen.getByTestId("badge")).toHaveTextContent("Sent");
+  });
+
+  it("renders a draft invoice with draft badge", () => {
+    // Given: an invoice with status "draft"
+    // When: InvoiceCard renders
+    render(<InvoiceCard invoice={{ ...base, status: "draft" }} />);
+
+    // Then: "Draft" badge is displayed
+    expect(screen.getByTestId("badge")).toHaveTextContent("Draft");
+  });
+
+  it("formats currency amount correctly", () => {
+    // Given: an invoice with amountCents of 15000 and currency "USD"
+    // When: InvoiceCard renders
+    render(<InvoiceCard invoice={{ ...base, amountCents: 15000, currency: "USD" }} />);
+
+    // Then: "$150.00" is displayed
+    expect(screen.getByText("$150.00")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #40

## What

Added Vitest + React Testing Library tests for two client portal components:

**InvoiceCard** (5 scenarios):
- Paid invoice renders "Paid" badge with no pay button
- Pending invoice with payment URL renders pay button link
- Overdue invoice (status "sent", past dueDate) renders "Sent" badge
- Draft invoice renders "Draft" badge
- Currency formatting: 15000 cents → "$150.00"

**FileUpload** (4 scenarios):
- Dropzone renders with upload button and "Choose a file" text
- Valid file selected by authenticated user triggers uploadBytesResumable
- File exceeding 25 MB shows error, does not upload
- Unauthenticated user selecting a file sees "Not authenticated." error

Also extended vitest.config.ts include pattern to cover .tsx test files.

## Agent

Worked by: engineering agent (worker agent inline execution)

---
Generated by BrewCortex worker agent