### PR TITLE
Build public FAQ page at /faq

### DIFF
--- a/app/(public)/faq/page.module.css
+++ b/app/(public)/faq/page.module.css
@@ -1,0 +1,13 @@
+.header {
+  max-width: var(--container-md);
+  margin-bottom: var(--space-14);
+}
+
+.title {
+  margin-top: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.subtitle {
+  max-width: 560px;
+}

--- a/app/(public)/faq/page.tsx
+++ b/app/(public)/faq/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import { getPublishedFAQsRest } from "@/lib/firestore/rest";
+import FAQAccordion from "@/components/public/FAQAccordion/FAQAccordion";
+import type { FAQ } from "@/lib/types";
+import styles from "./page.module.css";
+
+export const metadata: Metadata = {
+  title: "FAQ",
+  description: "Answers to common questions about TechByBrewski — our process, pricing, technology choices, and how we work with clients.",
+  alternates: { canonical: "/faq" },
+  openGraph: { images: ["/og-image.png"] },
+};
+
+function buildFAQSchema(faqs: FAQ[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
+}
+
+export default async function FAQPage() {
+  const faqs = await getPublishedFAQsRest();
+
+  return (
+    <section className="section">
+      <div className="container">
+        <div className={styles.header}>
+          <p className="text-overline">Knowledge Base</p>
+          <h1 className={`text-headline ${styles.title}`}>Frequently Asked Questions</h1>
+          <p className={`text-body-lg text-muted ${styles.subtitle}`}>
+            Everything you need to know about working with TechByBrewski.
+          </p>
+        </div>
+
+        <FAQAccordion faqs={faqs} />
+
+        {faqs.length > 0 && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(buildFAQSchema(faqs)) }}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/public/FAQAccordion/FAQAccordion.module.css
+++ b/components/public/FAQAccordion/FAQAccordion.module.css
@@ -1,0 +1,86 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.categorySection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.categoryHeading {
+  padding-bottom: var(--space-3);
+  border-bottom: 2px solid var(--color-accent);
+  display: inline-block;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.item {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  transition: box-shadow var(--transition-fast);
+}
+
+.itemOpen {
+  box-shadow: var(--shadow-warm-sm);
+}
+
+.question {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-5) var(--space-6);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  gap: var(--space-4);
+  transition: background var(--transition-fast);
+}
+
+.question:hover {
+  background: var(--color-surface-warm);
+}
+
+.chevron {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 8l5 5 5-5'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  transition: transform var(--transition-fast);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.answer {
+  padding: 0 var(--space-6) var(--space-5);
+}
+
+.answerText {
+  line-height: 1.7;
+}
+
+.empty {
+  padding: var(--space-12);
+  text-align: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+}

--- a/components/public/FAQAccordion/FAQAccordion.tsx
+++ b/components/public/FAQAccordion/FAQAccordion.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useState } from "react";
+import type { FAQ } from "@/lib/types";
+import styles from "./FAQAccordion.module.css";
+
+interface Props {
+  faqs: FAQ[];
+}
+
+function groupByCategory(faqs: FAQ[]): Record<string, FAQ[]> {
+  return faqs.reduce<Record<string, FAQ[]>>((acc, faq) => {
+    const key = faq.category || "General";
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(faq);
+    return acc;
+  }, {});
+}
+
+export default function FAQAccordion({ faqs }: Props) {
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  if (faqs.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <p className="text-body text-muted">No FAQs available yet. Check back soon.</p>
+      </div>
+    );
+  }
+
+  const grouped = groupByCategory(faqs);
+  const categories = Object.keys(grouped);
+
+  return (
+    <div className={styles.root}>
+      {categories.map((category) => (
+        <section key={category} className={styles.categorySection}>
+          <h2 className={`text-h3 ${styles.categoryHeading}`}>{category}</h2>
+          <div className={styles.list}>
+            {grouped[category].map((faq) => {
+              const isOpen = openId === faq.id;
+              return (
+                <div key={faq.id} className={`${styles.item} ${isOpen ? styles.itemOpen : ""}`}>
+                  <button
+                    className={styles.question}
+                    onClick={() => setOpenId(isOpen ? null : faq.id)}
+                    aria-expanded={isOpen}
+                    aria-controls={`faq-answer-${faq.id}`}
+                  >
+                    <span className="text-body">{faq.question}</span>
+                    <span className={`${styles.chevron} ${isOpen ? styles.chevronOpen : ""}`} aria-hidden="true" />
+                  </button>
+                  <div
+                    id={`faq-answer-${faq.id}`}
+                    className={styles.answer}
+                    hidden={!isOpen}
+                  >
+                    <p className={`text-body text-muted ${styles.answerText}`}>{faq.answer}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/components/public/Navbar/Navbar.tsx
+++ b/components/public/Navbar/Navbar.tsx
@@ -13,6 +13,7 @@ interface NavService {
 const STATIC_LINKS = [
   { label: "Work", href: "/case-studies" },
   { label: "Process", href: "/process" },
+  { label: "FAQ", href: "/faq" },
   { label: "About", href: "/about" },
   { label: "Client Portal", href: "/portal" },
 ];


### PR DESCRIPTION
Closes #24

## What
- Added `app/(public)/faq/page.tsx` — async server component that fetches all published FAQs via `getPublishedFAQsRest()` and renders the page with proper SEO metadata (title, description, canonical URL, og:image)
- Added `components/public/FAQAccordion/FAQAccordion.tsx` — client component that groups FAQs by `category`, renders category headings, and provides accessible accordion expand/collapse via `aria-expanded` + `hidden` attributes
- `application/ld+json` FAQ structured data injected server-side for Google rich results (only when FAQs exist)
- Graceful empty state rendered when no FAQs are published yet
- FAQ link added to `STATIC_LINKS` in `Navbar.tsx` — appears in both desktop nav and mobile menu

## Agent
Worked by: website agent (executed inline — 4 files, well-scoped)

---
Generated by BrewCortex worker agent