### PR TITLE
Style the public FAQ page

### DIFF
--- a/components/public/FAQAccordion/FAQAccordion.module.css
+++ b/components/public/FAQAccordion/FAQAccordion.module.css
@@ -53,6 +53,7 @@
   background: var(--color-surface-warm);
 }
 
+/* Chevron icon */
 .chevron {
   display: inline-block;
   width: 20px;
@@ -62,14 +63,31 @@
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  transition: transform var(--transition-fast);
+  transition: transform var(--transition-base);
 }
 
 .chevronOpen {
   transform: rotate(180deg);
 }
 
-.answer {
+/* Smooth accordion: grid row collapse technique */
+.answerWrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--transition-base);
+}
+
+.answerWrapperOpen {
+  grid-template-rows: 1fr;
+}
+
+.answerInner {
+  overflow: hidden;
+  padding: 0 var(--space-6) 0;
+  transition: padding var(--transition-base);
+}
+
+.answerWrapperOpen .answerInner {
   padding: 0 var(--space-6) var(--space-5);
 }
 
@@ -83,4 +101,15 @@
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-xl);
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .answerWrapper,
+  .answerInner,
+  .chevron,
+  .item,
+  .question {
+    transition: none;
+  }
 }

--- a/components/public/FAQAccordion/FAQAccordion.tsx
+++ b/components/public/FAQAccordion/FAQAccordion.tsx
@@ -51,10 +51,12 @@ export default function FAQAccordion({ faqs }: Props) {
                   </button>
                   <div
                     id={`faq-answer-${faq.id}`}
-                    className={styles.answer}
-                    hidden={!isOpen}
+                    className={`${styles.answerWrapper} ${isOpen ? styles.answerWrapperOpen : ""}`}
+                    aria-hidden={!isOpen}
                   >
-                    <p className={`text-body text-muted ${styles.answerText}`}>{faq.answer}</p>
+                    <div className={styles.answerInner}>
+                      <p className={`text-body text-muted ${styles.answerText}`}>{faq.answer}</p>
+                    </div>
                   </div>
                 </div>
               );


### PR DESCRIPTION
Closes #25

## What
- Replaced the `hidden` attribute on accordion answer panels with a CSS grid row collapse technique (`grid-template-rows: 0fr → 1fr`), enabling smooth height transitions without any JavaScript measuring
- Answer padding also transitions smoothly open/close
- Chevron rotation transition updated to `--transition-base` (200ms) for consistency with the panel animation
- Added `@media (prefers-reduced-motion: reduce)` block that disables all transitions for accessibility

All existing visual design (colors, spacing, border, shadow, category heading accent) is preserved unchanged.

## Agent
Worked by: website agent (inline execution — 2-file CSS/TSX change)

---
Generated by BrewCortex worker agent