### PR TITLE
fix: Services nav dropdown UX — hover gap closes menu, stays open after navigation

### DIFF
--- a/components/public/Navbar/Navbar.module.css
+++ b/components/public/Navbar/Navbar.module.css
@@ -97,11 +97,23 @@
   position: relative;
 }
 
+/* Invisible bridge fills the gap between the trigger and the panel
+   so the cursor doesn't leave the parent element while travelling down */
+.dropdown::before {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: var(--space-3);
+  /* transparent — only exists to keep pointer-events within .dropdown */
+}
+
 .dropdownMenu {
   position: absolute;
   top: calc(100% + var(--space-3));
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateY(-4px);
   min-width: 220px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
@@ -112,13 +124,11 @@
   flex-direction: column;
   opacity: 0;
   pointer-events: none;
-  transform: translateX(-50%) translateY(-4px);
   transition: opacity var(--transition-fast), transform var(--transition-fast);
   z-index: var(--z-dropdown);
 }
 
-.dropdown:hover .dropdownMenu,
-.dropdown:focus-within .dropdownMenu {
+.dropdownMenuOpen {
   opacity: 1;
   pointer-events: auto;
   transform: translateX(-50%) translateY(0);

--- a/components/public/Navbar/Navbar.tsx
+++ b/components/public/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSiteSettings } from "@/lib/context/SiteSettingsContext";
@@ -22,9 +22,38 @@ export default function Navbar({ services = [] }: { services?: NavService[] }) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [servicesOpen, setServicesOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const settings = useSiteSettings();
 
   const servicesActive = pathname.startsWith("/services");
+
+  // Close dropdown on route change
+  useEffect(() => {
+    setDropdownOpen(false);
+  }, [pathname]);
+
+  // Close dropdown on click-outside
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [dropdownOpen]);
+
+  // Close dropdown on Escape
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setDropdownOpen(false);
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [dropdownOpen]);
 
   return (
     <header className={styles.header}>
@@ -36,18 +65,32 @@ export default function Navbar({ services = [] }: { services?: NavService[] }) {
         {/* Desktop links */}
         <div className={styles.desktopLinks}>
           {/* Services with dropdown */}
-          <div className={styles.dropdown}>
+          <div
+            ref={dropdownRef}
+            className={styles.dropdown}
+            onMouseEnter={() => services.length > 0 && setDropdownOpen(true)}
+            onMouseLeave={() => setDropdownOpen(false)}
+          >
             <Link
               href="/services"
               className={`${styles.link} ${servicesActive ? styles.linkActive : ""}`}
               aria-haspopup="true"
-              aria-expanded={services.length > 0 ? undefined : false}
+              aria-expanded={dropdownOpen}
+              onClick={() => setDropdownOpen(false)}
             >
               Services
             </Link>
             {services.length > 0 && (
-              <div className={styles.dropdownMenu} role="menu" aria-label="Services">
-                <Link href="/services" className={styles.dropdownAll}>
+              <div
+                className={`${styles.dropdownMenu} ${dropdownOpen ? styles.dropdownMenuOpen : ""}`}
+                role="menu"
+                aria-label="Services"
+              >
+                <Link
+                  href="/services"
+                  className={styles.dropdownAll}
+                  onClick={() => setDropdownOpen(false)}
+                >
                   All Services →
                 </Link>
                 <div className={styles.dropdownDivider} />
@@ -56,6 +99,7 @@ export default function Navbar({ services = [] }: { services?: NavService[] }) {
                     key={s.slug}
                     href={`/services/${s.slug}`}
                     className={`${styles.dropdownItem} ${pathname === `/services/${s.slug}` ? styles.dropdownItemActive : ""}`}
+                    onClick={() => setDropdownOpen(false)}
                   >
                     {s.name}
                   </Link>


### PR DESCRIPTION
Closes #67

## What

- Converted the Services desktop dropdown from a CSS-only `:hover` trigger to JS-controlled state (`dropdownOpen`) driven by `onMouseEnter`/`onMouseLeave` on the wrapper `div`
- Added a `::before` pseudo-element on `.dropdown` that fills the visual gap between the trigger link and the panel, so the cursor travels across it without the parent losing hover state
- Added `useEffect` on `pathname` to close the dropdown on route change (fixes stay-open-after-navigation)
- Added a click-outside listener via `useRef` to close on click outside the nav element
- Added an Escape key handler
- Added `onClick={() => setDropdownOpen(false)}` on every dropdown link for immediate close on click

## Agent

Worked by: website agent (inline — two-file targeted fix)

---
Generated by BrewCortex worker agent