### PR TITLE
fix: resolve rollout build failures

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -74,7 +74,7 @@ export default async function HomePage() {
             <div className={styles.systemsGrid}>
               {services.map(s => (
                 <Link key={s.id} href={`/services/${s.slug}`} className={styles.systemChip}>
-                  {s.title}
+                  {s.name}
                 </Link>
               ))}
             </div>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:local": "env -u FIRESTORE_EMULATOR_HOST next build",
     "start": "next start",
     "lint": "next lint",
     "emulators": "firebase emulators:start --import=./emulator-data --export-on-exit",


### PR DESCRIPTION
## Summary
- Fixes `s.title` → `s.name` on homepage services chips (TypeScript error blocking App Hosting builds)
- Adds `build:local` npm script that unsets `FIRESTORE_EMULATOR_HOST` so `next build` works locally without the emulator running

## Root cause
`.env.local` sets `FIRESTORE_EMULATOR_HOST=127.0.0.1:8080` for dev. `npm run build` locally caused the Admin SDK to attempt a Firestore connection to the emulator, failing with ECONNREFUSED. App Hosting builds were unaffected (no emulator env var there). Use `npm run build:local` going forward for local build verification.

## Test plan
- [x] `npm run build:local` exits 0 locally
- [x] `tsc --noEmit` clean
- [x] CI should pass on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)