### PR TITLE
fix: blogPosts composite index and publishedAt mapping

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,14 @@
 {
   "indexes": [
     {
+      "collectionGroup": "blogPosts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isPublished", "order": "ASCENDING" },
+        { "fieldPath": "publishedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "services",
       "queryScope": "COLLECTION",
       "fields": [

--- a/lib/firestore/blog-rest.ts
+++ b/lib/firestore/blog-rest.ts
@@ -22,7 +22,7 @@ function toBlogPost(id: string, d: DocumentData): BlogPost {
     tags: (d.tags as string[]) ?? [],
     author: (d.author as string) ?? "",
     isPublished: (d.isPublished as boolean) ?? false,
-    publishedAt: null,
+    publishedAt: d.publishedAt ?? null,
     createdAt: d.createdAt ?? null,
     updatedAt: d.updatedAt ?? null,
   };


### PR DESCRIPTION
## Summary
- Add `(isPublished ASC, publishedAt DESC)` composite index for `blogPosts` — the missing index caused `getPublishedBlogPostsRest()` to silently return `[]` (error swallowed by `.catch(() => [])`)
- Fix `toBlogPost()` which hardcoded `publishedAt: null` instead of reading the value from the Firestore document

## Test plan
- [ ] Public `/blog` page renders published posts
- [ ] Admin `/admin/blog` page lists all posts
- [ ] Published posts show correct published date

🤖 Generated with [Claude Code](https://claude.com/claude-code)