### PR TITLE
fix(navbar): Services nav link vertically offset due to dropdown wrapper div

### DIFF
--- a/components/public/Navbar/Navbar.module.css
+++ b/components/public/Navbar/Navbar.module.css
@@ -95,6 +95,8 @@
 /* Services dropdown */
 .dropdown {
   position: relative;
+  display: flex;
+  align-items: center;
 }
 
 /* Invisible bridge fills the gap between the trigger and the panel


### PR DESCRIPTION
Closes #84

## What

The `.dropdown` wrapper div around the Services nav link was a plain block-level element. The `.desktopLinks` flex container centers its children with `align-items: center`, but a block div stretches to fill height and doesn't vertically center its inner content — causing the Services link to sit lower than sibling links.

Added `display: flex; align-items: center;` to `.dropdown` in `Navbar.module.css` so the wrapper participates correctly in the flex row.

## Agent

Worked by: engineering (inline — single-file CSS fix)

---
Generated by BrewCortex worker agent