### PR TITLE
fix(firestore): add blogPosts security rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -48,6 +48,12 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
+    // ---- Blog Posts ----
+    match /blogPosts/{id} {
+      allow read: if resource.data.isPublished == true || isAdmin();
+      allow write: if isAdmin();
+    }
+
     // ---- Contact Submissions ----
     // Anyone can create (public contact form); only admins can read
     match /contactSubmissions/{id} {


### PR DESCRIPTION
## Summary
- Added missing `blogPosts` Firestore security rule
- Allows public reads for published posts, admin reads/writes for all posts
- Matches the same pattern used by services, caseStudies, testimonials, and faqs

## Root Cause
The catch-all `deny-all` rule was blocking all client SDK reads on `blogPosts`. The public site worked because it uses the Admin SDK (bypasses rules), but the admin backend uses the client SDK and was silently denied.

## Test plan
- [ ] `/admin/blog` loads post list without errors
- [ ] Published posts still render on public `/blog` route
- [ ] Draft posts visible in admin, not on public site

🤖 Generated with [Claude Code](https://claude.com/claude-code)