### PR TITLE
chore: add BLOG_SCHEDULER_SECRET sync workflow

### DIFF
--- a/.github/workflows/sync-blog-secret.yml
+++ b/.github/workflows/sync-blog-secret.yml
@@ -1,0 +1,99 @@
+name: Sync BLOG_SCHEDULER_SECRET
+
+# Single source of truth for BLOG_SCHEDULER_SECRET. Writes the same value to:
+#   1. GitHub Actions secret (consumed by blog-scheduler.yml + blog-publisher.yml)
+#   2. Vercel env vars in production/preview/development (consumed by /api/blog/* routes)
+# Then triggers a Vercel production redeploy so the new value takes effect.
+#
+# Never edit BLOG_SCHEDULER_SECRET directly in either UI — always run this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_secret:
+        description: 'New secret value (leave blank to auto-generate a 48-char random string)'
+        required: false
+        type: string
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve secret value
+        id: resolve
+        env:
+          INPUT_SECRET: ${{ inputs.new_secret }}
+        run: |
+          if [ -z "$INPUT_SECRET" ]; then
+            VALUE=$(openssl rand -hex 24)
+            echo "Generated new 48-char secret"
+          else
+            VALUE="$INPUT_SECRET"
+            echo "Using provided secret"
+          fi
+          echo "::add-mask::$VALUE"
+          echo "value=$VALUE" >> $GITHUB_OUTPUT
+
+      - name: Update GitHub Actions secret
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_SECRETS_WRITE }}
+          NEW_VALUE: ${{ steps.resolve.outputs.value }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "ERROR: GH_PAT_SECRETS_WRITE secret is required (PAT with repo > secrets:write)" >&2
+            exit 1
+          fi
+          gh secret set BLOG_SCHEDULER_SECRET --body "$NEW_VALUE" --repo "${{ github.repository }}"
+          echo "✓ GitHub Actions secret updated"
+
+      - name: Update Vercel env vars (production, preview, development)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NEW_VALUE: ${{ steps.resolve.outputs.value }}
+        run: |
+          for required in VERCEL_TOKEN VERCEL_TEAM_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!required}" ]; then
+              echo "ERROR: $required secret is required" >&2
+              exit 1
+            fi
+          done
+
+          curl -sf "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_TEAM_ID" \
+            -H "Authorization: Bearer $VERCEL_TOKEN" > /tmp/envs.json
+
+          for TARGET in production preview development; do
+            ID=$(jq -r --arg t "$TARGET" '.envs[] | select(.key == "BLOG_SCHEDULER_SECRET" and (.target | index($t))) | .id' /tmp/envs.json | head -1)
+            if [ -n "$ID" ] && [ "$ID" != "null" ]; then
+              echo "Deleting existing $TARGET env var ($ID)..."
+              curl -sf -X DELETE "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env/$ID?teamId=$VERCEL_TEAM_ID" \
+                -H "Authorization: Bearer $VERCEL_TOKEN" > /dev/null
+            fi
+            echo "Creating new $TARGET env var..."
+            curl -sf -X POST "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/env?teamId=$VERCEL_TEAM_ID" \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -nc --arg v "$NEW_VALUE" --arg t "$TARGET" '{key:"BLOG_SCHEDULER_SECRET",value:$v,target:[$t],type:"encrypted"}')" > /dev/null
+          done
+          echo "✓ Vercel env vars updated across all 3 environments"
+
+      - name: Trigger Vercel production redeploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+        run: |
+          SHA=$(git rev-parse HEAD 2>/dev/null || echo "${{ github.sha }}")
+          curl -sf -X POST "https://api.vercel.com/v13/deployments?teamId=$VERCEL_TEAM_ID&forceNew=1" \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg repo "${{ github.repository }}" --arg sha "${{ github.sha }}" \
+              '{name:"techbybrewski",target:"production",gitSource:{type:"github",repo:$repo,ref:"main",sha:$sha}}')" \
+            | jq '{ id: .id, url: .url, readyState: .readyState }'
+          echo "✓ Redeploy triggered. Verify at https://vercel.com/brewski-beers-projects/techbybrewski"
+
+      - name: Verify scheduler endpoint after redeploy
+        run: |
+          echo "After deploy completes, verify with:"
+          echo "  gh workflow run blog-scheduler.yml"
+          echo "  gh run list --workflow=blog-scheduler.yml --limit 1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,15 @@
 - **Production URL:** https://techbybrewski.vercel.app/
 - **NEVER add `output: export`** — Firebase Admin SDK breaks on static export
 
+## Shared Secrets (GitHub Actions ↔ Vercel)
+
+`BLOG_SCHEDULER_SECRET` is consumed by both GitHub Actions (blog-scheduler.yml, blog-publisher.yml) and the Vercel runtime (`/api/blog/*`). To prevent drift:
+
+- **Single source of truth:** `.github/workflows/sync-blog-secret.yml` (workflow_dispatch). Writes the value to both GitHub Actions and all 3 Vercel envs, then redeploys.
+- **NEVER edit `BLOG_SCHEDULER_SECRET` directly in GitHub or Vercel UI** — always run the sync workflow. Manual edits caused a 6-week scheduler outage (Mar 23 → May 2 2026).
+- **Required GitHub secrets to run sync:** `GH_PAT_SECRETS_WRITE` (PAT with `repo > secrets:write`), `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID`.
+- **Same pattern for any future shared secret:** add a `sync-<name>.yml` workflow before introducing a second consumer.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- Adds \`.github/workflows/sync-blog-secret.yml\` as the single writer for \`BLOG_SCHEDULER_SECRET\` — pushes the same value to GitHub Actions and all 3 Vercel envs, then redeploys.
- Documents the rule in CLAUDE.md so future edits go through the workflow.

## Context
The blog scheduler has failed every Mon/Thu run since 2026-03-23 (curl exit 22 / 401). Root cause: \`BLOG_SCHEDULER_SECRET\` drifted between the GitHub secret and the Vercel env var during the Firebase App Hosting -> Vercel migration. Same class of bug as rush-n-relax's Apr 21-25 \`FIREBASE_SERVICE_ACCOUNT_JSON\` outage; same fix pattern (sync workflow as source of truth).

## Required GitHub secrets (add before first run)
- \`GH_PAT_SECRETS_WRITE\` — PAT with \`repo > secrets:write\`
- \`VERCEL_TOKEN\`
- \`VERCEL_TEAM_ID\`
- \`VERCEL_PROJECT_ID\`

## Test plan
- [ ] Add the 4 GitHub secrets above
- [ ] Run \`gh workflow run sync-blog-secret.yml\` (leave input blank to auto-generate)
- [ ] Confirm Vercel redeploy succeeds
- [ ] Run \`gh workflow run blog-scheduler.yml\` and verify it succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)