### PR TITLE
fix: blog scheduler reliability

### DIFF
--- a/.github/workflows/sync-blog-secret.yml
+++ b/.github/workflows/sync-blog-secret.yml
@@ -79,22 +79,49 @@ jobs:
             -d "$(jq -nc --arg v "$NEW_VALUE" '{key:"BLOG_SCHEDULER_SECRET",value:$v,target:["production","preview","development"],type:"encrypted"}')" > /dev/null
           echo "✓ Vercel env var updated across all 3 environments"
 
-      - name: Trigger Vercel production redeploy
+      - name: Redeploy production with new env
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          # Fetch the most recent READY production deployment ID, then redeploy it.
+          # This mirrors what `vercel redeploy <url>` does internally.
+          DEPLOY_ID=$(curl -sf "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_TEAM_ID&target=production&state=READY&limit=1" \
+            -H "Authorization: Bearer $VERCEL_TOKEN" | jq -r '.deployments[0].uid')
+          if [ -z "$DEPLOY_ID" ] || [ "$DEPLOY_ID" = "null" ]; then
+            echo "ERROR: could not find a READY production deployment to redeploy" >&2
+            exit 1
+          fi
+          echo "Redeploying $DEPLOY_ID..."
+          NEW_DEPLOY=$(curl -sf -X POST "https://api.vercel.com/v13/deployments?teamId=$VERCEL_TEAM_ID&forceNew=1" \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg id "$DEPLOY_ID" '{name:"techbybrewski",deploymentId:$id,target:"production"}')")
+          NEW_ID=$(echo "$NEW_DEPLOY" | jq -r '.id // .uid // empty')
+          NEW_URL=$(echo "$NEW_DEPLOY" | jq -r '.url // empty')
+          if [ -z "$NEW_ID" ]; then
+            echo "ERROR: redeploy did not return an ID. Response:" >&2
+            echo "$NEW_DEPLOY" | jq . >&2
+            exit 1
+          fi
+          echo "✓ Redeploy queued: $NEW_ID (https://$NEW_URL)"
+          echo "DEPLOY_ID=$NEW_ID" >> $GITHUB_ENV
+
+      - name: Wait for deploy to be READY
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
         run: |
-          SHA=$(git rev-parse HEAD 2>/dev/null || echo "${{ github.sha }}")
-          curl -sf -X POST "https://api.vercel.com/v13/deployments?teamId=$VERCEL_TEAM_ID&forceNew=1" \
-            -H "Authorization: Bearer $VERCEL_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -nc --arg repo "${{ github.repository }}" --arg sha "${{ github.sha }}" \
-              '{name:"techbybrewski",target:"production",gitSource:{type:"github",repo:$repo,ref:"main",sha:$sha}}')" \
-            | jq '{ id: .id, url: .url, readyState: .readyState }'
-          echo "✓ Redeploy triggered. Verify at https://vercel.com/brewski-beers-projects/techbybrewski"
-
-      - name: Verify scheduler endpoint after redeploy
-        run: |
-          echo "After deploy completes, verify with:"
-          echo "  gh workflow run blog-scheduler.yml"
-          echo "  gh run list --workflow=blog-scheduler.yml --limit 1"
+          for i in $(seq 1 40); do
+            STATE=$(curl -sf "https://api.vercel.com/v13/deployments/$DEPLOY_ID?teamId=$VERCEL_TEAM_ID" \
+              -H "Authorization: Bearer $VERCEL_TOKEN" | jq -r '.readyState')
+            echo "[$i] state=$STATE"
+            case "$STATE" in
+              READY) echo "✓ Deploy is READY"; exit 0 ;;
+              ERROR|CANCELED) echo "✗ Deploy ended in $STATE" >&2; exit 1 ;;
+            esac
+            sleep 15
+          done
+          echo "✗ Timed out waiting for deploy" >&2
+          exit 1

--- a/app/api/blog/generate/route.ts
+++ b/app/api/blog/generate/route.ts
@@ -60,6 +60,14 @@ async function callClaude(prompt: string, maxTokens: number): Promise<string> {
   return block.text;
 }
 
+function stripJsonFences(text: string): string {
+  return text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+}
+
 export async function POST(req: NextRequest) {
   if (!verifySecret(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -79,7 +87,7 @@ Return ONLY valid JSON (no markdown, no prose):
 { "topic": string, "why_interesting": string, "sources": [{ "name": string, "url": string }], "suggested_angle": string }`,
       1024
     );
-    research = JSON.parse(researchText) as ResearchResult;
+    research = JSON.parse(stripJsonFences(researchText)) as ResearchResult;
   } catch (err) {
     console.error("blog/generate: research step failed", err);
     const message = err instanceof Error ? err.message : "Research step failed";
@@ -111,7 +119,7 @@ Return ONLY valid JSON (no markdown, no code fences):
 { "title": string, "slug": string, "excerpt": string, "content": string, "tags": string[] }`,
       2048
     );
-    draft = JSON.parse(draftText) as DraftResult;
+    draft = JSON.parse(stripJsonFences(draftText)) as DraftResult;
   } catch (err) {
     console.error("blog/generate: draft step failed", err);
     const message = err instanceof Error ? err.message : "Draft step failed";


### PR DESCRIPTION
## Summary
- Strip markdown code fences from Claude responses before \`JSON.parse\` in [app/api/blog/generate/route.ts](app/api/blog/generate/route.ts) — Claude wraps JSON in \`\`\`json ... \`\`\` despite the prompt asking for raw JSON.
- Fix the redeploy step in [.github/workflows/sync-blog-secret.yml](.github/workflows/sync-blog-secret.yml) — previous \`gitSource\`-based POST returned 2xx but never created a deployment; new step does \`POST /v13/deployments\` with \`deploymentId\` of the latest READY production deploy (what \`vercel redeploy <url>\` does internally), then polls until READY.

## Context
Today's outage chain (2026-05-02):
1. \`BLOG_SCHEDULER_SECRET\` drift between GitHub and Vercel — fixed by sync workflow (#99)
2. \`ANTHROPIC_API_KEY\` was stale on Vercel — rotated manually
3. Anthropic call worked, but route choked on \`\`\`json fences — fixed here
4. Sync workflow's redeploy step never actually deployed — fixed here

After merge, re-run \`sync-blog-secret.yml\` (no input) to rotate \`BLOG_SCHEDULER_SECRET\` away from the temporary debug value currently in production.

## Test plan
- [ ] Merge
- [ ] Run \`gh workflow run sync-blog-secret.yml\` — confirm redeploy step waits for READY and exits 0
- [ ] Run \`gh workflow run blog-scheduler.yml\` — confirm a draft Issue gets opened (no curl exit 22, no JSON parse error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)