### PR TITLE
fix: grant blog-scheduler issues:write permission

### DIFF
--- a/.github/workflows/blog-scheduler.yml
+++ b/.github/workflows/blog-scheduler.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 15 * * 4'   # Thursday 10am EST
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   generate-draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add \`issues: write\` to [.github/workflows/blog-scheduler.yml](.github/workflows/blog-scheduler.yml). Final blocker after the auth chain was repaired — the draft is generated successfully, but the workflow's default \`GITHUB_TOKEN\` is read-only for issues, so \`createIssue\` fails with \`Resource not accessible by integration\`.

## Test plan
- [ ] Merge
- [ ] \`gh workflow run blog-scheduler.yml\` — confirm a new \`blog-draft\` Issue gets opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)