### PR TITLE
fix: avoid shell injection in blog publisher payload

### DIFF
--- a/.github/workflows/blog-publisher.yml
+++ b/.github/workflows/blog-publisher.yml
@@ -36,12 +36,20 @@ jobs:
 
       - name: Publish to Firestore
         id: publish
+        env:
+          BLOG_API_URL: ${{ secrets.BLOG_API_URL }}
+          BLOG_SCHEDULER_SECRET: ${{ secrets.BLOG_SCHEDULER_SECRET }}
+          PAYLOAD: ${{ steps.parse.outputs.payload }}
         run: |
-          RESPONSE=$(curl -sf -X POST "${{ secrets.BLOG_API_URL }}/api/blog/publish" \
-            -H "Authorization: Bearer ${{ secrets.BLOG_SCHEDULER_SECRET }}" \
+          RESPONSE=$(curl -sf -X POST "$BLOG_API_URL/api/blog/publish" \
+            -H "Authorization: Bearer $BLOG_SCHEDULER_SECRET" \
             -H "Content-Type: application/json" \
-            -d '${{ steps.parse.outputs.payload }}')
-          echo "result=$RESPONSE" >> $GITHUB_OUTPUT
+            --data-raw "$PAYLOAD")
+          {
+            echo "result<<EOF"
+            echo "$RESPONSE"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Comment success and close issue
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Pass the publish payload to the curl step via env var (\`PAYLOAD\`) rather than inlining \`\${{ steps.parse.outputs.payload }}\` inside bash single quotes. Apostrophes in post content (\"OpenAI's\", \"What's\") closed the bash quote, mangling the command. Switched to \`--data-raw \"\$PAYLOAD\"\` and made the GITHUB_OUTPUT capture multi-line-safe with a heredoc.

## Repro
- Issue #102 (\"I Threw OpenAI's Codex at a Real Project\")
- Comment \`/publish\` → workflow run [25260538808](https://github.com/brewski-beers/techbybrewski/actions/runs/25260538808) failed with \`syntax error near unexpected token '('\`

## Test plan
- [ ] Merge
- [ ] Re-comment \`/publish\` on #102 — confirm workflow succeeds, post lives on the site, issue auto-closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)