### PR TITLE
fix: grant blog-publisher issues:write permission

### DIFF
--- a/.github/workflows/blog-publisher.yml
+++ b/.github/workflows/blog-publisher.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   publish:
     if: |


### PR DESCRIPTION
## Summary
Add \`issues: write\` to [.github/workflows/blog-publisher.yml](.github/workflows/blog-publisher.yml). Same gap as #101 — the publish itself works (post #102 is live at https://techbybrewski.com/blog/openai-codex-real-project-what-actually-happened) but the comment + close step fails.

## Test plan
- [ ] Merge
- [ ] Manually close issue #102 (already published, just needs cleanup)
- [ ] Next \`/publish\` flow should comment + close automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)