### PR TITLE
ci(dependabot): adopt grouped weekly updates pattern from rush-n-relax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Next.js app dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 1
+    groups:
+      web-dependencies:
+        applies-to: version-updates
+        update-types: ['minor', 'patch']
+        patterns: ['*']
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 1
+    groups:
+      actions-dependencies:
+        applies-to: version-updates
+        update-types: ['minor', 'patch']
+        patterns: ['*']


### PR DESCRIPTION
Closes #107

## What
Add `.github/dependabot.yml` mirroring rush-n-relax's grouped weekly config. Batches all minor/patch updates per ecosystem (npm root + github-actions) into a single weekly PR each Monday at 06:00 ET. Major version bumps are ignored on npm so they surface as standalone issues for manual review.

## Why
Compresses the 20 currently-open Dependabot vulnerability alerts (1 critical, 8 high, 10 moderate, 1 low) into ~2 grouped PRs per cycle, drastically cutting review overhead.

## Notes
- techbybrewski has no `/functions` directory, so only the npm root + github-actions ecosystems are configured (rush-n-relax has 3 ecosystems).
- First grouped PR will open next Monday 06:00 ET.
- The 1 critical alert will need manual triage if it's a major bump (grouped config skips majors).

## Agent
Worked inline by worker agent (trivial single-file config change).

---
Generated by BrewCortex worker agent